### PR TITLE
Add @Objects and @Dependencies annotations.

### DIFF
--- a/DAGGER.md
+++ b/DAGGER.md
@@ -8,11 +8,11 @@ There are 3 ways to integrate Dagger components with Motif Scopes:
 
 ## Dagger Component as parent of Motif Scope
 
-For every Scope, Motif generates a `*ScopeImpl.Parent` interface, which declares the Scope's dependencies. The parent interface uses the same syntax as Dagger's Component [provision methods](https://google.github.io/dagger/api/2.14/dagger/Component.html#provision-methods) so a Dagger Component simply needs to implement the `*ScopeImpl.Parent` interface:
+For every Scope, Motif generates a `*ScopeImpl.Dependencies` interface, which declares the Scope's dependencies. The dependencies interface uses the same syntax as Dagger's Component [provision methods](https://google.github.io/dagger/api/2.14/dagger/Component.html#provision-methods) so a Dagger Component simply needs to implement the `*ScopeImpl.Dependencies` interface:
 
 ```java
 @dagger.Component
-interface Component extends MyScopeImpl.Parent {}
+interface Component extends MyScopeImpl.Dependencies {}
 
 Component component = ...;
 MyScope myScope = new MyScope(component);
@@ -23,11 +23,8 @@ MyScope myScope = new MyScope(component);
 Since Motif access methods share the same syntax as Dagger Component provision methods, a Motif Scope can be declared as a Component dependency:
 
 ```java
-@motif.Scope
-interface MyScope { ... }
-
 @dagger.Component(dependencies = MyScope.class)
-interface Component extends MyScopeImpl.Parent {}
+interface Component {}
 
 MyScope myScope = ...;
 Component component = DaggerComponent.builder()

--- a/README.md
+++ b/README.md
@@ -11,13 +11,11 @@ A Motif Scope is analogous to a Dagger `@Component`.
 </details>
 
 ```java
-import motif.Scope;
-
-@Scope
+@motif.Scope
 interface MainScope {}
 ```
 
-A specially named `Objects` class holds factory methods, which tell Motif how to create objects.
+A class annotated with `@motif.Objects` class holds factory methods, which tell Motif how to create objects.
 
 <details>
 <summary>Notes for Dagger users...</summary>
@@ -26,9 +24,10 @@ The nested `Objects` class is just like a Dagger `@Module` except Motif only all
 </details>
 
 ```java
-@Scope
+@motif.Scope
 interface MainScope {
 
+    @motif.Objects
     class Objects {
 
         Constroller controller() {
@@ -41,9 +40,10 @@ interface MainScope {
 Object dependencies can be passed into factory methods as parameters as long as Motif knows how to instantiate them as well:
 
 ```java
-@Scope
+@motif.Scope
 interface MainScope {
 
+    @motif.Objects
     class Objects {
 
         View view() {
@@ -70,11 +70,12 @@ Access methods are analogous to a Dagger `@Component` [provision methods](https:
 </details>
 
 ```java
-@Scope
+@motif.Scope
 interface MainScope {
 
     Controller controller();
 
+    @motif.Objects
     class Objects {
 
         View view() {
@@ -110,7 +111,7 @@ This is similar to a Dagger `@Subcomponent` [factory method](https://google.gith
 </details>
 
 ```java
-@Scope
+@motif.Scope
 interface MainScope {
 
     ChildScope child();
@@ -128,13 +129,14 @@ Unlike Dagger `@Subcomponents` which expose all objects down the graph by defaul
 </details>
 
 ```java
-@Scope
+@motif.Scope
 interface MainScope {
 
     ChildScope child();
 
     // ...
 
+    @motif.Objects
     class Objects {
 
         public Database database() {
@@ -145,11 +147,12 @@ interface MainScope {
     }
 }
 
-@Scope
+@motif.Scope
 interface ChildScope {
 
     ChildController controller();
 
+    @motif.Objects
     class Objects {
 
         // No Database factory method.
@@ -174,15 +177,16 @@ ChildScope childScope = mainScope.child();
 
 ## Root Scopes
 
-If Motif finds a nested interface named `Parent` on a Scope, it uses that interface to define exactly what is passed from the parent to the child. This is required in order for Motif to tell you when you have unsatisfied dependencies. The recommended pattern is to always declare an empty `Parent` interface on root Scopes:
+If Motif finds a nested interface annotated with `@Dependencies` on a Scope, it uses that interface to define exactly what this scope needs from its parent. This is required in order for Motif to tell you when you have unsatisfied dependencies. The recommended pattern is to always declare an empty `@Dependencies` interface on root Scopes:
 
 ```java
-@Scope
+@motif.Scope
 interface MainScope {
 
     // ...
-    
-    interface Parent {}
+
+    @motif.Dependencies
+    interface Dependencies {}
 }
 ```
 
@@ -199,11 +203,12 @@ This feature is similar to Dagger's `@Inject` constructor injection, but it does
 </details>
 
 ```java
-@Scope
+@motif.Scope
 interface MainScope {
 
     // ...
 
+    @motif.Objects
     abstract class Objects {
         abstract View view();
         abstract Database database();
@@ -220,11 +225,12 @@ interface ControllerObjects<C, V> {
     C controller();
 }
 
-@Scope
+@motif.Scope
 interface MainScope {
 
     // ...
 
+    @motif.Objects
     abstract class Objects implements ControllerObjects<Controller, View> {
         abstract Database database();
     }

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     compile 'com.google.dagger:dagger:2.16'
     compile 'commons-codec:commons-codec:1.11'
 
+    testCompile project(':stub-compiler')
     testCompile 'com.google.truth:truth:0.42'
     testCompile 'com.google.testing.compile:compile-testing:0.15'
 }

--- a/compiler/src/main/java/motif/compiler/codegen/ScopeConstructorSpec.kt
+++ b/compiler/src/main/java/motif/compiler/codegen/ScopeConstructorSpec.kt
@@ -16,11 +16,12 @@ class ScopeConstructorSpec(
             .addModifiers(Modifier.PUBLIC)
             .addParameter(parentParameter)
             .addStatement("this.\$N = \$T.builder()\n" +
-                    ".parent(\$N)\n" +
+                    ".\$N(\$N)\n" +
                     ".module(new \$T())\n" +
                     ".build()",
                     componentField.spec,
                     component.daggerClassName,
+                    parentInterface.className.simpleName().decapitalize(),
                     parentParameter,
                     module.className)
             .build()

--- a/compiler/src/main/java/motif/compiler/graph/ResolvedParent.kt
+++ b/compiler/src/main/java/motif/compiler/graph/ResolvedParent.kt
@@ -1,16 +1,14 @@
 package motif.compiler.graph
 
 import com.squareup.javapoet.ClassName
-import motif.compiler.asDeclaredType
+import motif.Dependencies
+import motif.compiler.*
 import motif.compiler.codegen.className
-import motif.compiler.innerInterfaces
 import motif.compiler.model.Dependency
 import motif.compiler.model.ParentInterface
 import motif.compiler.model.ParentInterfaceMethod
 import motif.compiler.names.Names
 import motif.compiler.names.UniqueNameSet
-import motif.compiler.serialize
-import motif.compiler.simpleName
 import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.type.DeclaredType
 
@@ -66,7 +64,7 @@ class ResolvedParent(
         }
 
         private fun DeclaredType.getParentInterface(): DeclaredType? {
-            return innerInterfaces().find { it.simpleName == Names.PARENT_INTERFACE_NAME }
+            return innerInterfaces().find { it.asElement().hasAnnotation(Dependencies::class) }
         }
     }
 }

--- a/compiler/src/main/java/motif/compiler/model/ScopeClass.kt
+++ b/compiler/src/main/java/motif/compiler/model/ScopeClass.kt
@@ -1,5 +1,7 @@
 package motif.compiler.model
 
+import motif.Dependencies
+import motif.Objects
 import motif.Scope
 import motif.compiler.*
 import motif.compiler.names.Names
@@ -58,11 +60,11 @@ class ScopeClass(
             }
 
             val objectsClass = type.innerTypes()
-                    .find { it.simpleName == Names.OBJECTS_CLASS_NAME }
+                    .find { it.asElement().hasAnnotation(Objects::class) }
                     ?.let { ObjectsClass.fromClass(env, it) }
 
             val parentInterface = type.innerInterfaces()
-                    .find { it.simpleName == Names.PARENT_INTERFACE_NAME }
+                    .find { it.asElement().hasAnnotation(Dependencies::class) }
                     ?.let { ParentInterface.create(env, it) }
 
             return ScopeClass(type, objectsClass, parentInterface, exposerMethods, childMethods)

--- a/compiler/src/main/java/motif/compiler/names/Names.kt
+++ b/compiler/src/main/java/motif/compiler/names/Names.kt
@@ -3,5 +3,5 @@ package motif.compiler.names
 object Names {
 
     val OBJECTS_CLASS_NAME = "Objects"
-    val PARENT_INTERFACE_NAME = "Parent"
+    val PARENT_INTERFACE_NAME = "Dependencies"
 }

--- a/it/src/main/java/testcases/E001_missing_dependency/Scope.java
+++ b/it/src/main/java/testcases/E001_missing_dependency/Scope.java
@@ -5,5 +5,6 @@ public interface Scope {
 
     String string();
 
-    interface Parent {}
+    @motif.Dependencies
+    interface Dependencies {}
 }

--- a/it/src/main/java/testcases/T002_access_method/Scope.java
+++ b/it/src/main/java/testcases/T002_access_method/Scope.java
@@ -5,6 +5,7 @@ public interface Scope {
 
     String string();
 
+    @motif.Objects
     class Objects {
 
         String string() {

--- a/it/src/main/java/testcases/T003_multiple_dependencies/Scope.java
+++ b/it/src/main/java/testcases/T003_multiple_dependencies/Scope.java
@@ -5,6 +5,7 @@ public interface Scope {
 
     String string();
 
+    @motif.Objects
     class Objects {
 
         String string(Integer i) {

--- a/it/src/main/java/testcases/T004_qualifier/Scope.java
+++ b/it/src/main/java/testcases/T004_qualifier/Scope.java
@@ -7,6 +7,7 @@ public interface Scope {
 
     String string();
 
+    @motif.Objects
     class Objects {
 
         String s(@Named("a") String a, @Named("b") String b) {

--- a/it/src/main/java/testcases/T005_custom_qualifier/Scope.java
+++ b/it/src/main/java/testcases/T005_custom_qualifier/Scope.java
@@ -5,6 +5,7 @@ public interface Scope {
 
     String string();
 
+    @motif.Objects
     class Objects {
 
         String s(@A String a, @B String b) {

--- a/it/src/main/java/testcases/T006_custom_qualifier_with_fields/Scope.java
+++ b/it/src/main/java/testcases/T006_custom_qualifier_with_fields/Scope.java
@@ -5,6 +5,7 @@ public interface Scope {
 
     String string();
 
+    @motif.Objects
     class Objects {
 
         String s(

--- a/it/src/main/java/testcases/T007_custom_qualifier_with_nested_annotation/Scope.java
+++ b/it/src/main/java/testcases/T007_custom_qualifier_with_nested_annotation/Scope.java
@@ -5,6 +5,7 @@ public interface Scope {
 
     String string();
 
+    @motif.Objects
     class Objects {
 
         String s(

--- a/it/src/main/java/testcases/T008_scope_dependency/Scope.java
+++ b/it/src/main/java/testcases/T008_scope_dependency/Scope.java
@@ -10,6 +10,7 @@ public interface Scope {
     @Named("a")
     String a();
 
+    @motif.Objects
     class Objects {
 
         String string(Scope scope) {

--- a/it/src/main/java/testcases/T009_dependency_cache/Scope.java
+++ b/it/src/main/java/testcases/T009_dependency_cache/Scope.java
@@ -7,6 +7,7 @@ public interface Scope {
 
     String string();
 
+    @motif.Objects
     class Objects {
 
         int i = 0;

--- a/it/src/main/java/testcases/T010_dependency_cache_donotcache/Scope.java
+++ b/it/src/main/java/testcases/T010_dependency_cache_donotcache/Scope.java
@@ -9,6 +9,7 @@ public interface Scope {
 
     String string();
 
+    @motif.Objects
     class Objects {
 
         int i = 0;

--- a/it/src/main/java/testcases/T011_inheritence_scope/Scope.java
+++ b/it/src/main/java/testcases/T011_inheritence_scope/Scope.java
@@ -3,6 +3,7 @@ package testcases.T011_inheritence_scope;
 @motif.Scope
 public interface Scope extends ScopeParent<String, Integer> {
 
+    @motif.Objects
     class Objects {
 
         String string() {

--- a/it/src/main/java/testcases/T012_inheritence_objects/Scope.java
+++ b/it/src/main/java/testcases/T012_inheritence_objects/Scope.java
@@ -14,5 +14,6 @@ public interface Scope {
     @Named("grandparent")
     String grandparent();
 
+    @motif.Objects
     abstract class Objects extends ObjectsParent<A, B> {}
 }

--- a/it/src/main/java/testcases/T013_override_scope/Scope.java
+++ b/it/src/main/java/testcases/T013_override_scope/Scope.java
@@ -6,6 +6,7 @@ public interface Scope extends ScopeParent {
     @Override
     String o();
 
+    @motif.Objects
     class Objects {
 
         String string() {

--- a/it/src/main/java/testcases/T014_override_objects/Scope.java
+++ b/it/src/main/java/testcases/T014_override_objects/Scope.java
@@ -5,6 +5,7 @@ public interface Scope {
 
     A a();
 
+    @motif.Objects
     abstract class Objects extends ObjectsParent {
 
         abstract A b();

--- a/it/src/main/java/testcases/T015_factory_method_constructor/Scope.java
+++ b/it/src/main/java/testcases/T015_factory_method_constructor/Scope.java
@@ -5,6 +5,7 @@ public interface Scope {
 
     A a();
 
+    @motif.Objects
     abstract class Objects {
         abstract A a();
     }

--- a/it/src/main/java/testcases/T016_factory_method_binds/Scope.java
+++ b/it/src/main/java/testcases/T016_factory_method_binds/Scope.java
@@ -5,6 +5,7 @@ public interface Scope {
 
     B b();
 
+    @motif.Objects
     abstract class Objects {
         abstract A a();
 

--- a/it/src/main/java/testcases/T017_spread/Scope.java
+++ b/it/src/main/java/testcases/T017_spread/Scope.java
@@ -13,6 +13,7 @@ public interface Scope {
     @Named("b")
     String b();
 
+    @motif.Objects
     abstract class Objects {
 
         @Spread

--- a/it/src/main/java/testcases/T018_spread_inheritence/Scope.java
+++ b/it/src/main/java/testcases/T018_spread_inheritence/Scope.java
@@ -13,6 +13,7 @@ public interface Scope {
     @Named("b")
     String b();
 
+    @motif.Objects
     abstract class Objects {
 
         @Spread

--- a/it/src/main/java/testcases/T019_nested_classes/Test.java
+++ b/it/src/main/java/testcases/T019_nested_classes/Test.java
@@ -14,6 +14,7 @@ public class Test {
 
         String string();
 
+        @motif.Objects
         abstract class Objects {
 
             String string() {

--- a/it/src/main/java/testcases/T020_naming_collisions/Test.java
+++ b/it/src/main/java/testcases/T020_naming_collisions/Test.java
@@ -26,6 +26,7 @@ public class Test {
 
         Parent p();
 
+        @motif.Objects
         abstract class Objects {
 
             public abstract testcases.T020_naming_collisions.c.SomeDependency c();

--- a/it/src/main/java/testcases/T021_objects_interface/Scope.java
+++ b/it/src/main/java/testcases/T021_objects_interface/Scope.java
@@ -5,6 +5,7 @@ public interface Scope {
 
     Dependency dependency();
 
+    @motif.Objects
     interface Objects {
 
         Dependency dependency();

--- a/it/src/main/java/testcases/T022_factory_method_constructor_dependencies/Scope.java
+++ b/it/src/main/java/testcases/T022_factory_method_constructor_dependencies/Scope.java
@@ -5,6 +5,7 @@ public interface Scope {
 
     B b();
 
+    @motif.Objects
     abstract class Objects {
         abstract A a();
         abstract B b();

--- a/it/src/main/java/testcases/T023_factory_method_binds_dependencies/Scope.java
+++ b/it/src/main/java/testcases/T023_factory_method_binds_dependencies/Scope.java
@@ -5,6 +5,7 @@ public interface Scope {
 
     B b();
 
+    @motif.Objects
     abstract class Objects {
         abstract A a();
 

--- a/it/src/main/java/testcases/T024_child/Child.java
+++ b/it/src/main/java/testcases/T024_child/Child.java
@@ -7,6 +7,7 @@ public interface Child {
 
     String string();
 
+    @motif.Objects
     class Objects {
 
         String string() {

--- a/it/src/main/java/testcases/T024_child/Scope.java
+++ b/it/src/main/java/testcases/T024_child/Scope.java
@@ -7,6 +7,7 @@ public interface Scope {
 
     Child child();
 
+    @motif.Objects
     class Objects {
 
         String string() {

--- a/it/src/main/java/testcases/T025_child_dependency_from_parent/Child.java
+++ b/it/src/main/java/testcases/T025_child_dependency_from_parent/Child.java
@@ -10,6 +10,7 @@ public interface Child {
     @Named("c")
     String string();
 
+    @motif.Objects
     class Objects {
 
         @Named("c")

--- a/it/src/main/java/testcases/T025_child_dependency_from_parent/Scope.java
+++ b/it/src/main/java/testcases/T025_child_dependency_from_parent/Scope.java
@@ -7,6 +7,7 @@ public interface Scope {
 
     Child child();
 
+    @motif.Objects
     class Objects {
 
         @Named("p")

--- a/it/src/main/java/testcases/T026_child_dynamic_dependency/Child.java
+++ b/it/src/main/java/testcases/T026_child_dynamic_dependency/Child.java
@@ -10,6 +10,7 @@ public interface Child {
     @Named("c")
     String string();
 
+    @motif.Objects
     class Objects {
 
         @Named("c")

--- a/it/src/main/java/testcases/T026_child_dynamic_dependency/Scope.java
+++ b/it/src/main/java/testcases/T026_child_dynamic_dependency/Scope.java
@@ -7,5 +7,6 @@ public interface Scope {
 
     Child child(@Named("p") String parent);
 
+    @motif.Objects
     class Objects {}
 }

--- a/lib/src/main/java/motif/Dependencies.java
+++ b/lib/src/main/java/motif/Dependencies.java
@@ -1,0 +1,3 @@
+package motif;
+
+public @interface Dependencies {}

--- a/lib/src/main/java/motif/Objects.java
+++ b/lib/src/main/java/motif/Objects.java
@@ -1,0 +1,3 @@
+package motif;
+
+public @interface Objects {}

--- a/sample/src/main/java/motif/sample/app/bottom_header/BottomHeaderScope.java
+++ b/sample/src/main/java/motif/sample/app/bottom_header/BottomHeaderScope.java
@@ -8,5 +8,6 @@ public interface BottomHeaderScope {
 
     BottomHeaderView view();
 
+    @motif.Objects
     abstract class Objects extends ControllerObjects<BottomHeaderController, BottomHeaderView> {}
 }

--- a/sample/src/main/java/motif/sample/app/bottom_sheet/BottomSheetScope.java
+++ b/sample/src/main/java/motif/sample/app/bottom_sheet/BottomSheetScope.java
@@ -16,5 +16,6 @@ public interface BottomSheetScope {
 
     PhotoListScope photoList(ViewGroup parent);
 
+    @motif.Objects
     abstract class Objects extends ControllerObjects<BottomSheetController, BottomSheetView> {}
 }

--- a/sample/src/main/java/motif/sample/app/photo_grid/PhotoGridScope.java
+++ b/sample/src/main/java/motif/sample/app/photo_grid/PhotoGridScope.java
@@ -13,6 +13,7 @@ public interface PhotoGridScope {
 
     PhotoGridItemScope photoRow(PhotoGridItemView view, Photo photo);
 
+    @motif.Objects
     abstract class Objects extends ControllerObjects<PhotoGridController, PhotoGridView> {
 
         abstract PhotoGridAdapter adapter();

--- a/sample/src/main/java/motif/sample/app/photo_grid_item/PhotoGridItemScope.java
+++ b/sample/src/main/java/motif/sample/app/photo_grid_item/PhotoGridItemScope.java
@@ -8,5 +8,6 @@ public interface PhotoGridItemScope {
 
     PhotoGridItemController controller();
 
+    @motif.Objects
     abstract class Objects extends ViewlessControllerObjects<PhotoGridItemController> {}
 }

--- a/sample/src/main/java/motif/sample/app/photo_list/PhotoListScope.java
+++ b/sample/src/main/java/motif/sample/app/photo_list/PhotoListScope.java
@@ -13,6 +13,7 @@ public interface PhotoListScope {
 
     PhotoListItemScope item(PhotoListItemView view, Photo photo);
 
+    @motif.Objects
     abstract class Objects extends ControllerObjects<PhotoListController, PhotoListView> {
 
         abstract PhotoListAdapter adapter();

--- a/sample/src/main/java/motif/sample/app/photo_list_item/PhotoListItemScope.java
+++ b/sample/src/main/java/motif/sample/app/photo_list_item/PhotoListItemScope.java
@@ -8,5 +8,6 @@ public interface PhotoListItemScope {
 
     PhotoListItemController controller();
 
+    @motif.Objects
     abstract class Objects extends ViewlessControllerObjects<PhotoListItemController> {}
 }

--- a/sample/src/main/java/motif/sample/app/root/RootScope.java
+++ b/sample/src/main/java/motif/sample/app/root/RootScope.java
@@ -19,13 +19,15 @@ public interface RootScope {
 
     BottomSheetScope bottomSheet(ViewGroup parent);
 
+    @motif.Objects
     abstract class Objects extends ControllerObjects<RootController, RootView> {
 
         public abstract Database database();
         public abstract MultiSelector multiSelector();
     }
 
-    interface Parent {
+    @motif.Dependencies
+    interface Dependencies {
 
         Context context();
     }


### PR DESCRIPTION
Use `@Objects` and `@Dependencies` instead of relying on special class names.