### PR TITLE
Don't reconfigure buildscript for every project.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,23 @@
 // https://github.com/gradle/gradle/issues/4848
 gradle.startParameter.configureOnDemand = false
 
-apply from: 'gradle/dependencies.gradle'
+
+buildscript {
+    apply from: 'gradle/dependencies.gradle'
+    repositories {
+        jcenter()
+        google()
+    }
+    dependencies {
+        classpath deps.build.gradlePlugins.android
+        classpath deps.build.gradlePlugins.kotlin
+        classpath deps.build.gradlePlugins.dokka
+        classpath deps.build.gradlePlugins.dokkaAndroid
+    }
+}
 
 subprojects {
     apply from: rootProject.file('gradle/dependencies.gradle')
-    buildscript {
-        repositories {
-            jcenter()
-            google()
-        }
-        dependencies {
-            classpath deps.build.gradlePlugins.android
-            classpath deps.build.gradlePlugins.kotlin
-            classpath deps.build.gradlePlugins.dokka
-            classpath deps.build.gradlePlugins.dokkaAndroid
-        }
-    }
 
     repositories {
         jcenter()

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -5,10 +5,6 @@ plugins {
 
 sourceCompatibility = 1.8
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compile deps.kotlin.stdlib
     compile deps.autoCommon


### PR DESCRIPTION
Set buildscript in root project instead.

This is the more conventional way of modifying the buildscript for
gradle projects.