### PR TITLE
Add Scope Navigation Icons only in Motif Scope Classes

### DIFF
--- a/plugin/src/main/kotlin/motif/intellij/MotifScopeLineMarkerProvider.kt
+++ b/plugin/src/main/kotlin/motif/intellij/MotifScopeLineMarkerProvider.kt
@@ -63,17 +63,18 @@ class MotifScopeLineMarkerProvider : RelatedItemLineMarkerProvider() {
             // the case when a child scope is declared in a class
             is PsiMethod -> {
                 val returnType = element.returnType ?: return
-                if (element.containingClass != null && !element.containingClass!!.isScopeClass()) return
-                scopeClassesMap.entries
-                        .find { it.key == returnType.getClass() }
-                        ?.let {
-                            val builder: NavigationGutterIconBuilder<PsiElement> =
-                                    NavigationGutterIconBuilder
-                                            .create(Icons.CHILD_SCOPE)
-                                            .setTooltipTitle("Navigate to Definition")
-                                            .setTargets(it.key)
-                            result.add(builder.createLineMarkerInfo(element))
-                        }
+                if (element.containingClass?.isScopeClass() == true) {
+                    scopeClassesMap.entries
+                            .find { it.key == returnType.getClass() }
+                            ?.let {
+                                val builder: NavigationGutterIconBuilder<PsiElement> =
+                                        NavigationGutterIconBuilder
+                                                .create(Icons.CHILD_SCOPE)
+                                                .setTooltipTitle("Navigate to Definition")
+                                                .setTargets(it.key)
+                                result.add(builder.createLineMarkerInfo(element))
+                            }
+                }
             }
         }
     }

--- a/plugin/src/main/kotlin/motif/intellij/MotifScopeLineMarkerProvider.kt
+++ b/plugin/src/main/kotlin/motif/intellij/MotifScopeLineMarkerProvider.kt
@@ -21,6 +21,7 @@ import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.psi.*
 import motif.intellij.icons.Icons
 import motif.intellij.psi.getClass
+import motif.intellij.psi.isScopeClass
 
 /**
  * This class is invoked when rendering the gutter on the side of a class in IntelliJ. It determines the pieces of
@@ -62,6 +63,7 @@ class MotifScopeLineMarkerProvider : RelatedItemLineMarkerProvider() {
             // the case when a child scope is declared in a class
             is PsiMethod -> {
                 val returnType = element.returnType ?: return
+                if (element.containingClass != null && !element.containingClass!!.isScopeClass()) return
                 scopeClassesMap.entries
                         .find { it.key == returnType.getClass() }
                         ?.let {


### PR DESCRIPTION
Add check in `MotifScopeLineMarkerProvider#collectNavigationMarkers` to add navigation markers only if the containing class is a Motif Scope. Fixes #8 