### PR TITLE
Allow exposing dynamic dependencies with the @Expose annotation.

### DIFF
--- a/compiler/src/main/java/motif/compiler/errors/ErrorHandler.kt
+++ b/compiler/src/main/java/motif/compiler/errors/ErrorHandler.kt
@@ -38,6 +38,7 @@ abstract class ErrorHandler<T> {
                 is DependencyCycleError -> DependencyCycleHandler().error(error)
                 is DuplicateFactoryMethodsError -> DuplicateFactoryMethodsHandler().error(error)
                 is NotExposedError -> NotExposedHandler().error(error)
+                is NotExposedDynamicError -> NotExposedDynamicHandler().error(error)
                 is ScopeMustBeAnInterface -> ScopeMustBeAnInterfaceHandler().error(error)
                 is InvalidScopeMethod -> InvalidScopeMethodHandler().error(error)
                 is ObjectsFieldFound -> ObjectsFieldFoundHandler().error(error)

--- a/compiler/src/main/java/motif/compiler/errors/validation/NotExposedDynamicHandler.kt
+++ b/compiler/src/main/java/motif/compiler/errors/validation/NotExposedDynamicHandler.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler.errors.validation
+
+import de.vandermeer.asciitable.AT_Context
+import de.vandermeer.asciitable.AsciiTable
+import de.vandermeer.asciithemes.u8.U8_Grids
+import motif.compiler.errors.ErrorHandler
+import motif.compiler.ir.CompilerMethod
+import motif.models.errors.NotExposedDynamicError
+import javax.lang.model.element.Element
+
+class NotExposedDynamicHandler : ErrorHandler<NotExposedDynamicError>() {
+
+    override fun message(error: NotExposedDynamicError): String {
+        val dependencyTable = AsciiTable(AT_Context()
+                .setGrid(U8_Grids.borderStrongDoubleLight())
+                .setWidth(60)).apply {
+            addRule()
+            addRow(error.requiredDependency.dependency).setPaddingLeft(1)
+            addRule()
+        }
+        val scopeTable = AsciiTable(AT_Context()
+                .setGrid(U8_Grids.borderStrongDoubleLight())
+                .setWidth(60)).apply {
+            addRule()
+            addRow(error.scopeClass.ir.type.simpleName).setPaddingLeft(1)
+            addRule()
+        }
+        val requiredByTable = AsciiTable(AT_Context()
+                .setGrid(U8_Grids.borderStrongDoubleLight())
+                .setWidth(60)).apply {
+            addRule()
+            error.requiredDependency.consumingScopes.forEach {
+                addRow(it.simpleName).setPaddingLeft(1)
+                addRule()
+            }
+        }
+        return StringBuilder().apply {
+            appendln("DYNAMIC DEPENDENCY NOT EXPOSED:")
+            appendln(dependencyTable.render())
+            appendln("is not exposed by:")
+            appendln(scopeTable.render())
+            appendln("but is required by:")
+            appendln(requiredByTable.render())
+        }.toString()
+    }
+
+    override fun element(error: NotExposedDynamicError): Element {
+        return (error.childMethod.ir as CompilerMethod).element
+    }
+}

--- a/it/src/main/java/testcases/E011_dynamic_dependency_not_exposed/Child.java
+++ b/it/src/main/java/testcases/E011_dynamic_dependency_not_exposed/Child.java
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testcases.E011_dynamic_dependency_internal;
+package testcases.E011_dynamic_dependency_not_exposed;
 
 @motif.Scope
 public interface Child {
 
     Grandchild grandchild();
-
-    String string();
 }

--- a/it/src/main/java/testcases/E011_dynamic_dependency_not_exposed/Grandchild.java
+++ b/it/src/main/java/testcases/E011_dynamic_dependency_not_exposed/Grandchild.java
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package motif.models.motif.child
+package testcases.E011_dynamic_dependency_not_exposed;
 
-import motif.models.java.IrMethod
-import motif.models.java.IrType
-import motif.models.motif.dependencies.DynamicDependency
+@motif.Scope
+public interface Grandchild {
 
-class ChildMethod(
-        val ir: IrMethod,
-        val scope: IrType,
-        val dynamicDependencies: List<DynamicDependency>)
+    String string();
+}

--- a/it/src/main/java/testcases/E011_dynamic_dependency_not_exposed/Scope.java
+++ b/it/src/main/java/testcases/E011_dynamic_dependency_not_exposed/Scope.java
@@ -13,19 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testcases.E011_dynamic_dependency_internal;
+package testcases.E011_dynamic_dependency_not_exposed;
 
-import common.MissingDependenciesSubject;
-import motif.models.errors.MissingDependenciesError;
-import motif.models.errors.MotifError;
+@motif.Scope
+public interface Scope {
 
-public class Test {
+    Child child(String string);
 
-    public static MotifError error;
-
-    public static void run() {
-        MissingDependenciesError error = (MissingDependenciesError) Test.error;
-        MissingDependenciesSubject.assertThat(error)
-                .matches(Grandchild.class, String.class);
-    }
+    @motif.Dependencies
+    interface Dependencies {}
 }

--- a/it/src/main/java/testcases/E011_dynamic_dependency_not_exposed/Test.java
+++ b/it/src/main/java/testcases/E011_dynamic_dependency_not_exposed/Test.java
@@ -13,13 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package motif.models.motif.child
+package testcases.E011_dynamic_dependency_not_exposed;
 
-import motif.models.java.IrMethod
-import motif.models.java.IrType
-import motif.models.motif.dependencies.DynamicDependency
+import motif.models.errors.NotExposedDynamicError;
 
-class ChildMethod(
-        val ir: IrMethod,
-        val scope: IrType,
-        val dynamicDependencies: List<DynamicDependency>)
+import static com.google.common.truth.Truth.assertThat;
+
+public class Test {
+
+    public static NotExposedDynamicError error;
+
+    public static void run() {
+        assertThat(error).isNotNull();
+    }
+}

--- a/it/src/main/java/testcases/T045_dynamic_dependency_expose/Child.java
+++ b/it/src/main/java/testcases/T045_dynamic_dependency_expose/Child.java
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testcases.E011_dynamic_dependency_internal;
+package testcases.T045_dynamic_dependency_expose;
 
 @motif.Scope
-public interface Scope {
+public interface Child {
 
-    Child child(String string);
+    Grandchild grandchild();
 
-    @motif.Dependencies
-    interface Dependencies {}
+    String string();
 }

--- a/it/src/main/java/testcases/T045_dynamic_dependency_expose/Grandchild.java
+++ b/it/src/main/java/testcases/T045_dynamic_dependency_expose/Grandchild.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testcases.E011_dynamic_dependency_internal;
+package testcases.T045_dynamic_dependency_expose;
 
 @motif.Scope
 public interface Grandchild {

--- a/it/src/main/java/testcases/T045_dynamic_dependency_expose/Scope.java
+++ b/it/src/main/java/testcases/T045_dynamic_dependency_expose/Scope.java
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package motif.models.motif.child
+package testcases.T045_dynamic_dependency_expose;
 
-import motif.models.java.IrMethod
-import motif.models.java.IrType
-import motif.models.motif.dependencies.DynamicDependency
+import motif.Expose;
 
-class ChildMethod(
-        val ir: IrMethod,
-        val scope: IrType,
-        val dynamicDependencies: List<DynamicDependency>)
+@motif.Scope
+public interface Scope {
+
+    Child child(@Expose String string);
+
+    @motif.Dependencies
+    interface Dependencies {}
+}

--- a/it/src/main/java/testcases/T045_dynamic_dependency_expose/Test.java
+++ b/it/src/main/java/testcases/T045_dynamic_dependency_expose/Test.java
@@ -13,13 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package motif.models.motif.child
+package testcases.T045_dynamic_dependency_expose;
 
-import motif.models.java.IrMethod
-import motif.models.java.IrType
-import motif.models.motif.dependencies.DynamicDependency
+import common.MissingDependenciesSubject;
+import motif.models.errors.MissingDependenciesError;
+import motif.models.errors.MotifError;
 
-class ChildMethod(
-        val ir: IrMethod,
-        val scope: IrType,
-        val dynamicDependencies: List<DynamicDependency>)
+import static com.google.common.truth.Truth.assertThat;
+
+public class Test {
+
+    public static void run() {
+        Scope scope = new ScopeImpl();
+        assertThat(scope.child("a").grandchild().string()).isEqualTo("a");
+    }
+}

--- a/models/src/main/kotlin/motif/models/errors/MotifError.kt
+++ b/models/src/main/kotlin/motif/models/errors/MotifError.kt
@@ -6,6 +6,7 @@ import motif.models.java.IrMethod
 import motif.models.java.IrParameter
 import motif.models.java.IrType
 import motif.models.motif.ScopeClass
+import motif.models.motif.child.ChildMethod
 import motif.models.motif.dependencies.Dependency
 import motif.models.motif.dependencies.RequiredDependency
 import motif.models.motif.objects.FactoryMethod
@@ -47,4 +48,12 @@ class ScopeCycleError(val cycle: List<IrType>) : MotifError()
 class NotExposedError(
         val scopeClass: ScopeClass,
         val factoryMethod: FactoryMethod,
+        val requiredDependency: RequiredDependency) : MotifError()
+
+/**
+ * Similar to NotExposedError except applied to dynamic dependencies.
+ */
+class NotExposedDynamicError(
+        val scopeClass: ScopeClass,
+        val childMethod: ChildMethod,
         val requiredDependency: RequiredDependency) : MotifError()

--- a/models/src/main/kotlin/motif/models/errors/MotifErrors.kt
+++ b/models/src/main/kotlin/motif/models/errors/MotifErrors.kt
@@ -21,9 +21,11 @@ class MotifErrors(
         private val missingDependenciesErrors: List<MissingDependenciesError>,
         private val dependencyCycleErrors: List<DependencyCycleError>,
         private val duplicateFactoryMethodsErrors: List<DuplicateFactoryMethodsError>,
-        private val notExposedErrors: List<NotExposedError>)
+        private val notExposedErrors: List<NotExposedError>,
+        private val notExposedDynamicErrors: List<NotExposedDynamicError>)
     : List<MotifError> by parsingErrors +
         notExposedErrors +
+        notExposedDynamicErrors +
         listOfNotNull(scopeCycleError) +
         duplicateFactoryMethodsErrors +
         dependencyCycleErrors +

--- a/models/src/main/kotlin/motif/models/graph/Graph.kt
+++ b/models/src/main/kotlin/motif/models/graph/Graph.kt
@@ -35,7 +35,8 @@ class Graph(
                 missingDependenciesError(),
                 dependencyCycleErrors(),
                 duplicateFactoryMethodsErrors(),
-                notExposedErrors())
+                notExposedErrors(),
+                notExposedDynamicErrors())
     }
 
     private fun missingDependenciesError(): List<MissingDependenciesError> {
@@ -68,6 +69,10 @@ class Graph(
 
     private fun notExposedErrors(): List<NotExposedError> {
         return nodes.values.flatMap { it.notExposedErrors }
+    }
+
+    private fun notExposedDynamicErrors(): List<NotExposedDynamicError> {
+        return nodes.values.flatMap { it.notExposedDynamicErrors }
     }
 
     fun getDependencies(scopeType: IrType): RequiredDependencies? {

--- a/models/src/main/kotlin/motif/models/motif/ScopeClass.kt
+++ b/models/src/main/kotlin/motif/models/motif/ScopeClass.kt
@@ -43,8 +43,8 @@ class ScopeClass(
     val notExposed: Map<Dependency, FactoryMethod> = factoryMethods.filter { !it.isExposed }.associateBy { it.providedDependency }
 
     val selfRequiredDependencies: RequiredDependencies by lazy {
-        val annotatedDependencies = (consumed - provided).map { RequiredDependency(it, false, setOf(ir.type)) }
-        RequiredDependencies(annotatedDependencies)
+        val requiredDependencies = (consumed - provided).map { RequiredDependency(it, false, setOf(ir.type)) }
+        RequiredDependencies(requiredDependencies)
     }
 
     override fun toString(): String {

--- a/models/src/main/kotlin/motif/models/motif/dependencies/DynamicDependency.kt
+++ b/models/src/main/kotlin/motif/models/motif/dependencies/DynamicDependency.kt
@@ -1,0 +1,5 @@
+package motif.models.motif.dependencies
+
+class DynamicDependency(
+        val dependency: Dependency,
+        val isExposed: Boolean)

--- a/models/src/main/kotlin/motif/models/parsing/ChildMethodParser.kt
+++ b/models/src/main/kotlin/motif/models/parsing/ChildMethodParser.kt
@@ -15,11 +15,12 @@
  */
 package motif.models.parsing
 
+import motif.Expose
 import motif.Scope
 import motif.models.java.IrClass
 import motif.models.java.IrMethod
-import motif.models.motif.dependencies.Dependency
 import motif.models.motif.child.ChildMethod
+import motif.models.motif.dependencies.DynamicDependency
 
 class ChildMethodParser : ParserUtil {
 
@@ -29,7 +30,9 @@ class ChildMethodParser : ParserUtil {
     }
 
     fun parse(method: IrMethod): ChildMethod {
-        val dynamicDependencies: List<Dependency> = method.parameters.map { it.toDependency() }
+        val dynamicDependencies: List<DynamicDependency> = method.parameters.map {
+            DynamicDependency(it.toDependency(), it.hasAnnotation(Expose::class))
+        }
         return ChildMethod(method, method.returnType, dynamicDependencies)
     }
 }


### PR DESCRIPTION
Before this change, exposing a dynamic dependency to grandchildren (or further descendants) would require this pattern:

```java
@Scope
interface ParentScope {
  ChildScope child(@Named("dynamic") String string);

  @motif.Dependencies
  interface Dependencies {}
}

@Scope
interface ChildScope {
  GrandChildScope grandchild();

  @motif.Objects
  class Objects {
  
    @Expose
    String string(@Named("dynamic") String s);
  }
}

@Scope
interface GrandChildScope {
  String string();
}
```

To simplify this use case, this PR updates the API to allow annotating dynamic dependencies with `@Expose`:

```java
@Scope
interface ParentScope {
  ChildScope child(@Expose String string);

  @motif.Dependencies
  interface Dependencies {}
}

@Scope
interface ChildScope {
  GrandChildScope grandchild();
}

@Scope
interface GrandChildScope {
  String string();
}
```