### PR TITLE
Add support for members-injection methods

### DIFF
--- a/it/src/main/java/testcases/T045_inject_method/Scope.java
+++ b/it/src/main/java/testcases/T045_inject_method/Scope.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T045_inject_method;
+
+import testcases.T045_inject_method.other.OtherTarget;
+
+@motif.Scope
+public interface Scope {
+
+    void inject(Target target);
+
+    OtherTarget poke(OtherTarget target);
+
+    @motif.Objects
+    class Objects {
+
+        static String s() {
+            return "s";
+        }
+    }
+
+    @motif.Dependencies
+    interface Dependencies {}
+}

--- a/it/src/main/java/testcases/T045_inject_method/Target.java
+++ b/it/src/main/java/testcases/T045_inject_method/Target.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T045_inject_method;
+
+import javax.inject.Inject;
+
+public class Target {
+    @Inject String s;
+}

--- a/it/src/main/java/testcases/T045_inject_method/Test.java
+++ b/it/src/main/java/testcases/T045_inject_method/Test.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T045_inject_method;
+
+import testcases.T045_inject_method.Scope;
+import testcases.T045_inject_method.other.OtherTarget;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class Test {
+
+    public static void run() {
+        Scope scope = new ScopeImpl();
+        Target target = new Target();
+        OtherTarget otherTarget = new OtherTarget();
+
+        scope.inject(target);
+        OtherTarget returnValue = scope.poke(otherTarget);
+
+        assertThat(target.s).isEqualTo("s");
+        assertThat(otherTarget.s).isEqualTo("s");
+        assertThat(returnValue.s).isEqualTo("s");
+    }
+}

--- a/it/src/main/java/testcases/T045_inject_method/other/OtherTarget.java
+++ b/it/src/main/java/testcases/T045_inject_method/other/OtherTarget.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T045_inject_method.other;
+
+import javax.inject.Inject;
+
+public class OtherTarget {
+    @Inject public String s;
+}

--- a/models/src/main/kotlin/motif/models/graph/Scope.kt
+++ b/models/src/main/kotlin/motif/models/graph/Scope.kt
@@ -20,6 +20,7 @@ import motif.models.motif.accessmethod.AccessMethod
 import motif.models.motif.dependencies.Dependency
 import motif.models.motif.child.ChildMethod
 import motif.models.motif.dependencies.RequiredDependencies
+import motif.models.motif.inject.InjectMethod
 import motif.models.motif.objects.ObjectsClass
 
 class Scope(
@@ -29,6 +30,7 @@ class Scope(
 
     val childMethods: List<ChildMethod> = scopeClass.childMethods
     val accessMethods: List<AccessMethod> = scopeClass.accessMethods
+    val injectMethods: List<InjectMethod> = scopeClass.injectMethods
     val objectsClass: ObjectsClass? = scopeClass.objectsClass
     val scopeDependency: Dependency = scopeClass.scopeDependency
 }

--- a/models/src/main/kotlin/motif/models/motif/ScopeClass.kt
+++ b/models/src/main/kotlin/motif/models/motif/ScopeClass.kt
@@ -22,6 +22,7 @@ import motif.models.motif.child.ChildMethod
 import motif.models.motif.dependencies.ExplicitDependencies
 import motif.models.motif.dependencies.RequiredDependencies
 import motif.models.motif.dependencies.RequiredDependency
+import motif.models.motif.inject.InjectMethod
 import motif.models.motif.objects.FactoryMethod
 import motif.models.motif.objects.ObjectsClass
 
@@ -29,6 +30,7 @@ class ScopeClass(
         val ir: IrClass,
         val childMethods: List<ChildMethod>,
         val accessMethods: List<AccessMethod>,
+        val injectMethods: List<InjectMethod>,
         val objectsClass: ObjectsClass?,
         val explicitDependencies: ExplicitDependencies?) {
 

--- a/models/src/main/kotlin/motif/models/motif/inject/InjectMethod.kt
+++ b/models/src/main/kotlin/motif/models/motif/inject/InjectMethod.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.models.motif.inject
+
+import motif.models.java.IrMethod
+import motif.models.java.IrParameter
+import motif.models.java.IrType
+
+class InjectMethod(
+        val ir: IrMethod,
+        val target: IrParameter)

--- a/models/src/main/kotlin/motif/models/parsing/InjectMethodParser.kt
+++ b/models/src/main/kotlin/motif/models/parsing/InjectMethodParser.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.models.parsing
+
+import motif.models.java.IrMethod
+import motif.models.motif.inject.InjectMethod
+
+class InjectMethodParser : ParserUtil {
+
+    fun isApplicable(method: IrMethod): Boolean {
+        return method.parameters.size == 1 && (
+                method.isVoid() || method.returnType == method.parameters[0].type
+        )
+    }
+
+    fun parse(method: IrMethod): InjectMethod {
+        return InjectMethod(method, method.parameters[0])
+    }
+}

--- a/models/src/main/kotlin/motif/models/parsing/ScopeClassParser.kt
+++ b/models/src/main/kotlin/motif/models/parsing/ScopeClassParser.kt
@@ -23,12 +23,14 @@ import motif.models.motif.ScopeClass
 import motif.models.motif.accessmethod.AccessMethod
 import motif.models.motif.child.ChildMethod
 import motif.models.motif.dependencies.ExplicitDependencies
+import motif.models.motif.inject.InjectMethod
 import motif.models.motif.objects.ObjectsClass
 
 class ScopeClassParser {
 
     private val childMethodParser = ChildMethodParser()
     private val accessMethodParser = AccessMethodParser()
+    private val injectMethodParser = InjectMethodParser()
     private val objectsClassParser = ObjectsClassParser()
     private val explicitDependenciesParser = ExplicitDependenciesParser()
 
@@ -38,12 +40,14 @@ class ScopeClassParser {
 
         val childMethods: MutableList<ChildMethod> = mutableListOf()
         val accessMethods: MutableList<AccessMethod> = mutableListOf()
+        val injectMethods: MutableList<InjectMethod> = mutableListOf()
 
         irScopeClass.methods
                 .forEach {
                     when {
                         childMethodParser.isApplicable(it) -> childMethods.add(childMethodParser.parse(it))
                         accessMethodParser.isApplicable(it) -> accessMethods.add(accessMethodParser.parse(it))
+                        injectMethodParser.isApplicable(it) -> injectMethods.add(injectMethodParser.parse(it))
                         else -> throw InvalidScopeMethod(it)
                     }
                 }
@@ -55,6 +59,7 @@ class ScopeClassParser {
                 irScopeClass,
                 childMethods,
                 accessMethods,
+                injectMethods,
                 objectsClass,
                 explicitDependencies)
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Motif. Before pressing the "Create Pull Request" button, please consider the following
points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Adds support for [Dagger-like members-injection methods](https://google.github.io/dagger/api/2.6/dagger/Component.html#members-injection-methods) (excluding MembersInjector) to Scopes:

```
@motif.Scope
public interface Scope {

    void inject(Target target);
    OtherTarget poke(OtherTarget target);

    @motif.Objects
    class Objects {
        static String s() {
            return "s";
        }
    }
}
```

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
https://github.com/uber/motif/issues/27

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
