### PR TITLE
Add test for static spreadable method

### DIFF
--- a/it/src/main/java/testcases/T046_spread_static_spreadable_method/Scope.java
+++ b/it/src/main/java/testcases/T046_spread_static_spreadable_method/Scope.java
@@ -13,14 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testcases.T045_dynamic_dependency_expose;
+package testcases.T046_spread_static_spreadable_method;
 
-import static com.google.common.truth.Truth.assertThat;
+import motif.Spread;
 
-public class Test {
+@motif.Scope
+public interface Scope {
 
-    public static void run() {
-        Scope scope = new ScopeImpl();
-        assertThat(scope.child("a").grandchild().string()).isEqualTo("a");
+    String a();
+
+    @motif.Objects
+    abstract class Objects {
+
+        @Spread
+        abstract Spreadable spreadable();
     }
+
+    @motif.Dependencies
+    interface Dependencies {}
 }

--- a/it/src/main/java/testcases/T046_spread_static_spreadable_method/Spreadable.java
+++ b/it/src/main/java/testcases/T046_spread_static_spreadable_method/Spreadable.java
@@ -13,14 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testcases.T045_dynamic_dependency_expose;
+package testcases.T046_spread_static_spreadable_method;
 
-import static com.google.common.truth.Truth.assertThat;
+public class Spreadable {
 
-public class Test {
-
-    public static void run() {
-        Scope scope = new ScopeImpl();
-        assertThat(scope.child("a").grandchild().string()).isEqualTo("a");
+    public static String a() {
+        return "a";
     }
 }

--- a/it/src/main/java/testcases/T046_spread_static_spreadable_method/Test.java
+++ b/it/src/main/java/testcases/T046_spread_static_spreadable_method/Test.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testcases.T045_dynamic_dependency_expose;
+package testcases.T046_spread_static_spreadable_method;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -21,6 +21,6 @@ public class Test {
 
     public static void run() {
         Scope scope = new ScopeImpl();
-        assertThat(scope.child("a").grandchild().string()).isEqualTo("a");
+        assertThat(scope.a()).isEqualTo("a");
     }
 }


### PR DESCRIPTION
Fixes #44 
Static methods should also be spreadable. Add a test to verify this behavior.
