### PR TITLE
Various Bug Fixes

### DIFF
--- a/compiler/src/main/java/motif/compiler/codegen/ChildMethodFactory.kt
+++ b/compiler/src/main/java/motif/compiler/codegen/ChildMethodFactory.kt
@@ -61,7 +61,7 @@ class ChildMethodFactory(
             val componentMethod = componentMethods[dependency]
             when {
                 dynamicDependency != null -> addStatement("return \$N", dynamicDependency.element.simpleName)
-                componentMethod != null -> addStatement("return \$N.\$N()", scope.componentFieldSpec, componentMethod)
+                componentMethod != null -> addStatement("return \$T.this.\$N.\$N()", scope.implTypeName, scope.componentFieldSpec, componentMethod)
                 else -> throw IllegalStateException("Could not satisfy dependency: $dependency")
             }
             return this

--- a/it/src/main/java/testcases/E036_no_suitable_constructor_interface/Foo.java
+++ b/it/src/main/java/testcases/E036_no_suitable_constructor_interface/Foo.java
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package motif;
+package testcases.E036_no_suitable_constructor_interface;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
-@Target(ElementType.METHOD)
-public @interface Spread {}
+public interface Foo {}

--- a/it/src/main/java/testcases/E036_no_suitable_constructor_interface/Scope.java
+++ b/it/src/main/java/testcases/E036_no_suitable_constructor_interface/Scope.java
@@ -13,10 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package motif;
+package testcases.E036_no_suitable_constructor_interface;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
+@motif.Scope
+public interface Scope {
 
-@Target(ElementType.METHOD)
-public @interface Spread {}
+    @motif.Objects
+    abstract class Objects {
+
+        abstract Foo i();
+    }
+}

--- a/it/src/main/java/testcases/E036_no_suitable_constructor_interface/Test.java
+++ b/it/src/main/java/testcases/E036_no_suitable_constructor_interface/Test.java
@@ -13,10 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package motif;
+package testcases.E036_no_suitable_constructor_interface;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
+import motif.models.errors.MotifError;
+import motif.models.errors.NoSuitableConstructor;
 
-@Target(ElementType.METHOD)
-public @interface Spread {}
+import static com.google.common.truth.Truth.assertThat;
+
+public class Test {
+
+    public static MotifError error;
+
+    public static void run() {
+        assertThat(error).isInstanceOf(NoSuitableConstructor.class);
+    }
+}

--- a/it/src/main/java/testcases/T047_dynamic_dependency_named_component/Child.java
+++ b/it/src/main/java/testcases/T047_dynamic_dependency_named_component/Child.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package motif;
+package testcases.T047_dynamic_dependency_named_component;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
+import motif.Scope;
 
-@Target(ElementType.METHOD)
-public @interface Spread {}
+@Scope
+public interface Child {
+
+    String string();
+}

--- a/it/src/main/java/testcases/T047_dynamic_dependency_named_component/Scope.java
+++ b/it/src/main/java/testcases/T047_dynamic_dependency_named_component/Scope.java
@@ -13,10 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package motif;
+package testcases.T047_dynamic_dependency_named_component;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
+import motif.Expose;
 
-@Target(ElementType.METHOD)
-public @interface Spread {}
+@motif.Scope
+public interface Scope {
+
+    Child child(Integer component);
+
+    @motif.Objects
+    class Objects {
+
+        @Expose
+        String string() {
+            return "s";
+        }
+    }
+
+    @motif.Dependencies
+    interface Dependencies {}
+}

--- a/it/src/main/java/testcases/T047_dynamic_dependency_named_component/Test.java
+++ b/it/src/main/java/testcases/T047_dynamic_dependency_named_component/Test.java
@@ -13,10 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package motif;
+package testcases.T047_dynamic_dependency_named_component;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
+import static com.google.common.truth.Truth.assertThat;
 
-@Target(ElementType.METHOD)
-public @interface Spread {}
+public class Test {
+
+    public static void run() {
+        Scope scope = new ScopeImpl();
+        Child child = scope.child(1);
+        assertThat(child.string()).isEqualTo("s");
+    }
+}

--- a/models/src/main/kotlin/motif/models/parsing/ObjectsClassParser.kt
+++ b/models/src/main/kotlin/motif/models/parsing/ObjectsClassParser.kt
@@ -80,6 +80,10 @@ class ObjectsClassParser : ParserUtil {
         val returnType = method.returnType
         val returnClass: IrClass = returnType.resolveClass() ?: throw NoSuitableConstructor(returnType, method)
 
+        if (returnClass.isAbstract()) {
+            throw NoSuitableConstructor(returnType, method)
+        }
+
         val constructors: List<IrMethod> = returnClass.constructors
 
         val requiredDependencies: RequiredDependencies = if (constructors.isEmpty()) {


### PR DESCRIPTION
Fixes #46 #47 #48 #49 
- `@Spread ` only applies to methods
- Support dynamic dependencies named "component"
- Better error message for interface constructor factory method