### PR TITLE
Handle @Expose + @Spread correctly.

### DIFF
--- a/it/src/main/java/testcases/E037_spread_not_exposed/Child.java
+++ b/it/src/main/java/testcases/E037_spread_not_exposed/Child.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.E037_spread_not_exposed;
+
+@motif.Scope
+public interface Child {
+
+    String a();
+}

--- a/it/src/main/java/testcases/E037_spread_not_exposed/Scope.java
+++ b/it/src/main/java/testcases/E037_spread_not_exposed/Scope.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.E037_spread_not_exposed;
+
+import motif.Spread;
+
+@motif.Scope
+public interface Scope {
+
+    Child child();
+
+    @motif.Objects
+    abstract class Objects {
+
+        @Spread
+        abstract Spreadable spreadable();
+    }
+
+    @motif.Dependencies
+    interface Dependencies {}
+}

--- a/it/src/main/java/testcases/E037_spread_not_exposed/Spreadable.java
+++ b/it/src/main/java/testcases/E037_spread_not_exposed/Spreadable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.E037_spread_not_exposed;
+
+public class Spreadable {
+
+    public String a() {
+        return "a";
+    }
+}

--- a/it/src/main/java/testcases/E037_spread_not_exposed/Test.java
+++ b/it/src/main/java/testcases/E037_spread_not_exposed/Test.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.E037_spread_not_exposed;
+
+import motif.models.errors.MotifError;
+import motif.models.errors.NotExposedError;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class Test {
+
+    public static MotifError error;
+
+    public static void run() {
+        assertThat(error).isInstanceOf(NotExposedError.class);
+    }
+}

--- a/it/src/main/java/testcases/T048_expose_spread_factory_method/Child.java
+++ b/it/src/main/java/testcases/T048_expose_spread_factory_method/Child.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T048_expose_spread_factory_method;
+
+@motif.Scope
+public interface Child {
+
+    String a();
+}

--- a/it/src/main/java/testcases/T048_expose_spread_factory_method/Scope.java
+++ b/it/src/main/java/testcases/T048_expose_spread_factory_method/Scope.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T048_expose_spread_factory_method;
+
+import motif.Expose;
+import motif.Spread;
+
+@motif.Scope
+public interface Scope {
+
+    Child child();
+
+    @motif.Objects
+    abstract class Objects {
+
+        @Expose
+        @Spread
+        abstract Spreadable spreadable();
+    }
+
+    @motif.Dependencies
+    interface Dependencies {}
+}

--- a/it/src/main/java/testcases/T048_expose_spread_factory_method/Spreadable.java
+++ b/it/src/main/java/testcases/T048_expose_spread_factory_method/Spreadable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T048_expose_spread_factory_method;
+
+public class Spreadable {
+
+    public String a() {
+        return "a";
+    }
+}

--- a/it/src/main/java/testcases/T048_expose_spread_factory_method/Test.java
+++ b/it/src/main/java/testcases/T048_expose_spread_factory_method/Test.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T048_expose_spread_factory_method;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class Test {
+
+    public static void run() {
+        Scope scope = new ScopeImpl();
+        assertThat(scope.child().a()).isEqualTo("a");
+    }
+}

--- a/models/src/main/kotlin/motif/models/motif/ScopeClass.kt
+++ b/models/src/main/kotlin/motif/models/motif/ScopeClass.kt
@@ -40,7 +40,15 @@ class ScopeClass(
 
     private val consumed: List<Dependency> = factoryMethods.flatMap { it.requiredDependencies.list }.map { it.dependency } + accessMethods.map { it.dependency }
 
-    val notExposed: Map<Dependency, FactoryMethod> = factoryMethods.filter { !it.isExposed }.associateBy { it.providedDependency }
+    val notExposed: Map<Dependency, FactoryMethod> = factoryMethods
+            .filter { !it.isExposed }
+            .flatMap { method ->
+                method.providedDependencies.map { provided ->
+                    provided to method
+                }
+            }
+            .toMap()
+
 
     val selfRequiredDependencies: RequiredDependencies by lazy {
         val requiredDependencies = (consumed - provided).map { RequiredDependency(it, false, setOf(ir.type)) }


### PR DESCRIPTION
Previously we were auto-exposing all @Spread dependencies. Now correctly expose @Spread dependencies only when annotated with @Expose.