### PR TITLE
Make ScopeImpl.Module static and abstract.

### DIFF
--- a/compiler/src/main/java/motif/compiler/codegen/CodegenCache.kt
+++ b/compiler/src/main/java/motif/compiler/codegen/CodegenCache.kt
@@ -60,6 +60,10 @@ open class CodegenCache(
         implTypeName.nestedClass("Component")
     }
 
+    val Scope.componentBuilderTypeName: ClassName by cache {
+        componentTypeName.nestedClass("Builder")
+    }
+
     val Scope.dependenciesTypeName: ClassName by cache {
         implTypeName.nestedClass(GENERATED_DEPENDENCIES_NAME)
     }

--- a/models/src/main/kotlin/motif/models/motif/objects/FactoryMethod.kt
+++ b/models/src/main/kotlin/motif/models/motif/objects/FactoryMethod.kt
@@ -30,15 +30,16 @@ class FactoryMethod(
         val providedDependency: Dependency,
         val spreadDependency: SpreadDependency?) {
 
-    val isAbstract: Boolean = kind.isAbstract
+    val isAbstract: Boolean = ir.isAbstract()
+    val isStatic: Boolean = ir.isStatic()
 
     val providedDependencies: List<Dependency> by lazy {
         (spreadDependency?.methods?.map { it.dependency } ?: listOf()) + providedDependency
     }
 
-    enum class Kind (val isAbstract: Boolean) {
-        BASIC(isAbstract = false),
-        BINDS(isAbstract = true),
-        CONSTRUCTOR(isAbstract = true);
+    enum class Kind {
+        BASIC,
+        BINDS,
+        CONSTRUCTOR;
     }
 }


### PR DESCRIPTION
Fixes #53

* Make Module static and abstract.
* Use `@BindsInstance` to provide `FooScope` instance.
* Call Objects methods statically if static.

```java
@motif.Scope
public interface FooScope {

    @motif.Objects
    class Objects {

        static String s() {
            return "s";
        }
    }
}
```

```java
@ScopeImpl(
    children = {},
    scope = FooScope.class,
    dependencies = FooScopeImpl.Dependencies.class
)
public class FooScopeImpl implements FooScope {
  private final Component component;

  public FooScopeImpl(Dependencies dependencies) {
    this.component = DaggerFooScopeImpl_Component.builder()
        .dependencies(dependencies)
        .scope(this)
        .build();
  }

  public FooScopeImpl() {
    this(new Dependencies() {});
  }

  public interface Dependencies {
  }

  @DaggerScope
  @dagger.Component(
      dependencies = Dependencies.class,
      modules = Module.class
  )
  interface Component {
    @dagger.Component.Builder
    interface Builder {
      Builder dependencies(Dependencies dependencies);

      @BindsInstance
      Builder scope(FooScope scope);

      Component build();
    }
  }

  private static class Objects extends FooScope.Objects {
  }

  @dagger.Module
  abstract static class Module {
    private static final FooScope.Objects objects = new Objects();

    @Provides
    @DaggerScope
    static String string() {
      return FooScope.Objects.s();
    }
  }
}
```