### PR TITLE
Fix compiler test inputs.

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 test {
-    inputs.files(file("$rootDir/it/src"))
+    inputs.files(file("$rootDir/tests/src"))
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
Test input directory was incorrect after module refactoring. This change allows correct invalidation of the compiler test task.