### PR TITLE
Fix license test.

### DIFF
--- a/compiler/src/test/java/license/LicenseTest.kt
+++ b/compiler/src/test/java/license/LicenseTest.kt
@@ -25,18 +25,6 @@ class LicenseTest {
 
     @Rule @JvmField val temporaryFolder = TemporaryFolder()
 
-    private val modules = sequenceOf(
-            "lib",
-            "compiler",
-            "samples/sample",
-            "samples/sample-kotlin",
-            "samples/sample-lib",
-            "samples/dagger-comparison",
-            "plugin",
-            "ir",
-            "it",
-            "stub-compiler")
-
     private val licenseText = """
         /*
          * Copyright (c) 2018 Uber Technologies, Inc.
@@ -57,7 +45,13 @@ class LicenseTest {
 
     @Test
     fun test() {
-        val missingLicenses = modules.flatMap { File("../$it/src").walk() }
+        val srcDirs = File("..").walk()
+                .filter { file ->
+                    file.name == "src"
+                            && file.isDirectory
+                            && file.resolveSibling("build.gradle").exists()
+                }
+        val missingLicenses = srcDirs.flatMap { srcDir -> srcDir.walk() }
                 .filter { it.extension == "java" || it.extension == "kt" }
                 .filter { !it.ensureLicense() }
                 .toList()

--- a/core/src/main/kotlin/motif/models/errors/MotifError.kt
+++ b/core/src/main/kotlin/motif/models/errors/MotifError.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package motif.models.errors
 
 import motif.models.graph.Node

--- a/core/src/main/kotlin/motif/models/motif/dependencies/DynamicDependency.kt
+++ b/core/src/main/kotlin/motif/models/motif/dependencies/DynamicDependency.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package motif.models.motif.dependencies
 
 class DynamicDependency(


### PR DESCRIPTION
Previous LicenseTest implementation relied on hardcoded module directories and was unsurprisingly out of date. Update the logic to no longer use hardcoded paths and identify source directories by name (`src`) and existence of a sibling `build.gradle` file.