### PR TITLE
Add codegen logic for new Motif compiler.

### DIFF
--- a/compiler2/README.md
+++ b/compiler2/README.md
@@ -1,0 +1,2 @@
+Top-level module for the Motif annotation processor. This module contains the `Processor` itself 
+and all code generation logic. The module will also run the Dagger annotation processor.

--- a/compiler2/build.gradle
+++ b/compiler2/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'org.jetbrains.dokka'
+}
+
+sourceCompatibility = 1.8
+
+dependencies {
+    implementation deps.kotlin.stdlib
+    implementation deps.autoCommon
+    implementation deps.commonsCodec
+    implementation deps.javapoet
+    implementation deps.dagger
+    implementation deps.daggerCompiler
+    implementation project(':lib')
+    implementation project(':compiler-ast')
+    implementation project(':core2')
+    implementation project(':errormessage')
+
+    testImplementation deps.test.truth
+    testImplementation deps.test.compileTesting
+}
+
+test {
+    inputs.files(file("$rootDir/tests/src"))
+}
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/compiler2/gradle.properties
+++ b/compiler2/gradle.properties
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2018. Uber Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+POM_NAME=Motif
+# TODO Update artifact id
+POM_ARTIFACT_ID=motif-compiler2
+POM_PACKAGING=jar

--- a/compiler2/src/main/kotlin/motif/compiler/Component.kt
+++ b/compiler2/src/main/kotlin/motif/compiler/Component.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import com.squareup.javapoet.AnnotationSpec
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.TypeSpec
+import motif.core.ResolvedGraph
+import motif.internal.DaggerScope
+import motif.models.Scope
+import motif.models.Type
+import java.util.*
+import javax.lang.model.element.Modifier
+
+class Component private constructor(
+        val spec: TypeSpec,
+        val typeName: ClassName,
+        val builder: ComponentBuilder,
+        private val methodSpecs: Map<Type, MethodSpec>) {
+
+    fun getMethodSpec(type: Type): MethodSpec {
+        return methodSpecs[type]
+                ?: throw NullPointerException("Could not find Component method for Type: ${type.qualifiedName}")
+    }
+
+    companion object {
+
+        fun create(
+                graph: ResolvedGraph,
+                scope: Scope,
+                dependencies: Dependencies,
+                module: Module,
+                childImpls: List<ChildImpl>,
+                scopeTypeName: ClassName,
+                scopeImplTypeName: ClassName): Component {
+            val typeName = scopeImplTypeName.nestedClass("Component")
+
+            val builder = ComponentBuilder.create(dependencies, scopeTypeName, typeName)
+            val methodSpecs = componentMethodSpecs(graph, scope, childImpls)
+
+            val typeSpec = TypeSpec.interfaceBuilder(typeName)
+            typeSpec.addAnnotation(DaggerScope::class.java)
+            typeSpec.addAnnotation(AnnotationSpec.builder(dagger.Component::class.java)
+                    .addMember("dependencies", "\$T.class", dependencies.typeName)
+                    .addMember("modules", "\$T.class", module.typeName)
+                    .build())
+            typeSpec.addMethods(methodSpecs.values)
+            typeSpec.addType(builder.spec)
+
+            return Component(typeSpec.build(), typeName, builder, methodSpecs)
+        }
+
+        private fun componentMethodSpecs(
+                graph: ResolvedGraph,
+                scope: Scope,
+                children: List<ChildImpl>): SortedMap<Type, MethodSpec> {
+            val nameScope = NameScope()
+            val requiredTypes = (scope.accessMethods.map { it.returnType } +
+                    children.flatMap { childImpl -> graph.getChildUnsatisfied(childImpl.child).map { it.type } })
+                    .toSet()
+            return requiredTypes.associate { type ->
+                val methodSpec = methodSpec(nameScope, type)
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                type to methodSpec.build()
+            }.toSortedMap()
+        }
+    }
+}

--- a/compiler2/src/main/kotlin/motif/compiler/ComponentBuilder.kt
+++ b/compiler2/src/main/kotlin/motif/compiler/ComponentBuilder.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.TypeSpec
+import dagger.BindsInstance
+import dagger.Component
+import javax.lang.model.element.Modifier
+
+class ComponentBuilder private constructor(
+        val spec: TypeSpec,
+        val typeName: ClassName,
+        val dependenciesMethod: MethodSpec,
+        val scopeMethod: MethodSpec,
+        val buildMethod: MethodSpec) {
+
+    companion object {
+
+        fun create(
+                dependencies: Dependencies,
+                scopeTypeName: ClassName,
+                componentTypeName: ClassName): ComponentBuilder {
+            val typeName = componentTypeName.nestedClass("Builder")
+            val typeSpec = TypeSpec.interfaceBuilder(typeName)
+            typeSpec.addAnnotation(Component.Builder::class.java)
+            typeSpec.addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+
+            val dependenciesMethod = MethodSpec.methodBuilder("dependencies")
+                    .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                    .returns(typeName)
+                    .addParameter(dependencies.typeName, "dependencies")
+                    .build()
+
+            val scopeMethod = MethodSpec.methodBuilder("scope")
+                    .addAnnotation(BindsInstance::class.java)
+                    .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                    .returns(typeName)
+                    .addParameter(scopeTypeName, "scope")
+                    .build()
+
+            val buildMethod = MethodSpec.methodBuilder("build")
+                    .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                    .returns(componentTypeName)
+                    .build()
+
+            typeSpec.addMethods(listOf(
+                    dependenciesMethod,
+                    scopeMethod,
+                    buildMethod
+            ))
+
+            return ComponentBuilder(typeSpec.build(), typeName, dependenciesMethod, scopeMethod, buildMethod)
+        }
+    }
+}

--- a/compiler2/src/main/kotlin/motif/compiler/Dependencies.kt
+++ b/compiler2/src/main/kotlin/motif/compiler/Dependencies.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.TypeName
+import com.squareup.javapoet.TypeSpec
+import motif.core.ResolvedGraph
+import motif.models.Scope
+import motif.models.Type
+import java.util.*
+import javax.lang.model.element.Modifier
+
+class Dependencies private constructor(
+        val spec: TypeSpec,
+        val typeName: TypeName,
+        private val methodSpecs: SortedMap<Type, Method>) {
+
+    private val methodList = methodSpecs.values.toList()
+
+    fun getMethodSpec(type: Type): MethodSpec? {
+        return methodSpecs[type]?.methodSpec
+    }
+
+    fun isEmpty(): Boolean {
+        return methodSpecs.isEmpty()
+    }
+
+    fun types(): List<Type> {
+        return methodSpecs.keys.toList()
+    }
+
+    fun getMethods(): List<Method> {
+        return methodList
+    }
+
+    class Method(val type: Type, val methodSpec: MethodSpec)
+
+    companion object {
+
+        fun create(
+                graph: ResolvedGraph,
+                scope: Scope,
+                scopeImplTypeName: ClassName): Dependencies {
+            val sinks = graph.getUnsatisfied(scope)
+            val nameScope = NameScope()
+            val typeName = scopeImplTypeName.nestedClass("Dependencies")
+
+            val methods: SortedMap<Type, Method> = sinks
+                    .map { it.type }
+                    .toSet()
+                    .associateWith { type ->
+                        val methodSpec = methodSpec(nameScope, type)
+                                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                                .build()
+                        Method(type, methodSpec)
+                    }
+                    .toSortedMap()
+
+            val typeSpec = TypeSpec.interfaceBuilder(typeName)
+                    .addModifiers(Modifier.PUBLIC)
+                    .addMethods(methods.values.map { it.methodSpec })
+                    .build()
+
+            return Dependencies(typeSpec, typeName, methods)
+        }
+    }
+}

--- a/compiler2/src/main/kotlin/motif/compiler/Module.kt
+++ b/compiler2/src/main/kotlin/motif/compiler/Module.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import com.squareup.javapoet.*
+import motif.models.*
+import javax.lang.model.element.Modifier
+
+class Module private constructor(
+        val spec: TypeSpec,
+        val typeName: ClassName) {
+
+    companion object {
+
+        fun create(
+                scope: Scope,
+                objectsImpl: ObjectsImpl?,
+                scopeImplTypeName: ClassName): Module {
+            val typeName = scopeImplTypeName.nestedClass("Module")
+            val typeSpec = TypeSpec.classBuilder(typeName)
+            typeSpec.addAnnotation(dagger.Module::class.java)
+            typeSpec.addModifiers(Modifier.STATIC, Modifier.ABSTRACT)
+
+            if (objectsImpl == null) {
+                return Module(typeSpec.build(), typeName)
+            }
+
+            val objectsField = objectsField(objectsImpl)
+
+            typeSpec.addField(objectsField)
+
+            val nameScope = NameScope()
+
+            val methodSpecs = objectsImpl.objects.factoryMethods
+                    .flatMap { factoryMethod -> methodSpecs(nameScope, factoryMethod, objectsField) }
+
+            typeSpec.addMethods(methodSpecs)
+
+            return Module(typeSpec.build(), typeName)
+        }
+
+        private fun methodSpecs(
+                nameScope: NameScope,
+                factoryMethod: FactoryMethod,
+                objectsField: FieldSpec): List<MethodSpec> {
+            val methodSpec = methodSpec(nameScope, factoryMethod, objectsField)
+            val spreadMethodSpecs = spreadMethodSpecs(nameScope, factoryMethod)
+            return spreadMethodSpecs + methodSpec
+        }
+
+        private fun methodSpec(
+                nameScope: NameScope,
+                factoryMethod: FactoryMethod,
+                objectsField: FieldSpec): MethodSpec {
+            val methodSpec = providerMethod(nameScope, factoryMethod.returnType.type, factoryMethod.isCached)
+            val parameterNameScope = NameScope()
+            val parameterSpecs = factoryMethod.parameters
+                    .map { parameter -> parameterSpec(parameterNameScope, parameter.type) }
+            methodSpec.addParameters(parameterSpecs)
+
+            val returnStatement = returnStatement(factoryMethod, parameterSpecs, objectsField)
+            methodSpec.addStatement(returnStatement)
+
+            return methodSpec.build()
+        }
+
+        private fun returnStatement(
+                factoryMethod: FactoryMethod,
+                parameterSpecs: List<ParameterSpec>,
+                objectsField: FieldSpec): CodeBlock {
+            val callParams: String = parameterSpecs.joinToString(", ") { "\$N" }
+            val methodName = factoryMethod.name
+            val parameterSpecArray = parameterSpecs.toTypedArray()
+            val returnType = factoryMethod.returnType.type
+            return when (factoryMethod) {
+                is BasicFactoryMethod -> {
+                    if (factoryMethod.isStatic) {
+                        CodeBlock.of("return \$T.\$N($callParams)", objectsField.type, methodName, *parameterSpecArray)
+                    } else {
+                        CodeBlock.of("return \$N.\$N($callParams)", objectsField, methodName, *parameterSpecArray)
+                    }
+                }
+                is BindsFactoryMethod -> CodeBlock.of("return $callParams", *parameterSpecArray)
+                is ConstructorFactoryMethod -> CodeBlock.of("return new \$T($callParams)", returnType.typeName, *parameterSpecArray)
+            }
+        }
+
+        private fun spreadMethodSpecs(nameScope: NameScope, factoryMethod: FactoryMethod): List<MethodSpec> {
+            return factoryMethod.spread?.let { spread ->
+                spread.methods.map { spreadMethod -> spreadMethodSpec(nameScope, spreadMethod) }
+            } ?: emptyList()
+        }
+
+        private fun spreadMethodSpec(nameScope: NameScope, spreadMethod: Spread.Method): MethodSpec {
+            val returnType = spreadMethod.returnType
+            val parameterSpec = parameterSpec(spreadMethod.sourceType, "source")
+            val methodSpec = providerMethod(nameScope, returnType, spreadMethod.spread.factoryMethod.isCached)
+            methodSpec.addParameter(parameterSpec)
+            methodSpec.addStatement("return \$N.\$N()", parameterSpec, spreadMethod.name)
+            return methodSpec.build()
+        }
+
+        private fun providerMethod(
+                nameScope: NameScope,
+                type: Type,
+                isCached: Boolean): MethodSpec.Builder {
+            return methodSpec(nameScope, type)
+                    .addAnnotation(dagger.Provides::class.java)
+                    .addModifiers(Modifier.STATIC)
+                    .apply { if (isCached) addAnnotation(motif.internal.DaggerScope::class.java) }
+        }
+
+        private fun objectsField(objectsImpl: ObjectsImpl): FieldSpec {
+            return FieldSpec.builder(
+                    objectsImpl.objectsName,
+                    "objects",
+                    Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                    .initializer("new \$T()", objectsImpl.objectsImplName)
+                    .build()
+        }
+    }
+}

--- a/compiler2/src/main/kotlin/motif/compiler/ObjectsImpl.kt
+++ b/compiler2/src/main/kotlin/motif/compiler/ObjectsImpl.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.TypeSpec
+import motif.ast.IrClass
+import motif.ast.compiler.CompilerClass
+import motif.models.Objects
+import motif.models.Scope
+import javax.annotation.processing.ProcessingEnvironment
+import javax.lang.model.element.Modifier
+
+class ObjectsImpl private constructor(
+        val spec: TypeSpec,
+        val objects: Objects,
+        val objectsName: ClassName,
+        val objectsImplName: ClassName) {
+
+    companion object {
+
+        fun create(env: ProcessingEnvironment, scope: Scope, scopeImplTypeName: ClassName): ObjectsImpl? {
+            val objects = scope.objects ?: return null
+            val objectsClass = objects.clazz as CompilerClass
+            val objectsName = objectsClass.typeName
+            val objectsImplName = scopeImplTypeName.nestedClass("Objects")
+
+            val typeSpec = TypeSpec.classBuilder(objectsImplName)
+            typeSpec.addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+            if (objectsClass.kind == IrClass.Kind.INTERFACE) {
+                typeSpec.addSuperinterface(objectsName)
+            } else {
+                typeSpec.superclass(objectsName)
+            }
+
+            val overriddenMethods = scope.factoryMethods
+                    .filter { it.method.isAbstract() }
+                    .map {
+                        overrideSpec(env, it.method)
+                                .addStatement("throw new \$T()", UnsupportedOperationException::class.java)
+                                .build()
+                    }
+            typeSpec.addMethods(overriddenMethods)
+
+            return ObjectsImpl(typeSpec.build(), objects, objectsName, objectsImplName)
+        }
+    }
+}

--- a/compiler2/src/main/kotlin/motif/compiler/Processor.kt
+++ b/compiler2/src/main/kotlin/motif/compiler/Processor.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import com.squareup.javapoet.JavaFile
+import motif.ast.compiler.CompilerClass
+import motif.core.ResolvedGraph
+import motif.errormessage.ErrorMessage
+import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.SourceVersion
+import javax.lang.model.element.TypeElement
+import javax.lang.model.type.DeclaredType
+import javax.tools.Diagnostic
+
+class Processor : AbstractProcessor() {
+
+    lateinit var graph: ResolvedGraph
+
+    override fun getSupportedSourceVersion(): SourceVersion {
+        return SourceVersion.latestSupported()
+    }
+
+    override fun getSupportedAnnotationTypes(): Set<String> {
+        return setOf(motif.Scope::class.java.name)
+    }
+
+    override fun process(annotations: Set<TypeElement>, roundEnv: RoundEnvironment): Boolean {
+        if (roundEnv.processingOver()) {
+            return true
+        }
+        process(roundEnv)
+        return true
+    }
+
+    private fun process(roundEnv: RoundEnvironment) {
+        val initialScopeClasses = roundEnv.getElementsAnnotatedWith(motif.Scope::class.java)
+                .map { CompilerClass(processingEnv, it.asType() as DeclaredType) }
+        if (initialScopeClasses.isEmpty()) {
+            return
+        }
+
+        this.graph = ResolvedGraph.create(initialScopeClasses)
+
+        if (graph.errors.isNotEmpty()) {
+            val errorMessage = ErrorMessage.toString(graph)
+            processingEnv.messager.printMessage(Diagnostic.Kind.ERROR, errorMessage)
+            return
+        }
+
+        val scopeImpls = ScopeImpl.create(processingEnv, graph)
+
+        scopeImpls.forEach { scopeImpl ->
+            val spec = scopeImpl.spec ?: return@forEach
+            JavaFile.builder(scopeImpl.packageName, spec).build().writeTo(processingEnv.filer)
+        }
+    }
+}

--- a/compiler2/src/main/kotlin/motif/compiler/ScopeImpl.kt
+++ b/compiler2/src/main/kotlin/motif/compiler/ScopeImpl.kt
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import com.squareup.javapoet.*
+import motif.core.Child
+import motif.core.ResolvedGraph
+import motif.models.*
+import javax.annotation.processing.ProcessingEnvironment
+import javax.lang.model.element.Modifier
+
+class ChildImpl(val child: Child, val impl: ScopeImpl) {
+
+    fun getParameter(type: Type): ChildMethod.Parameter? {
+        return child.method.parameters.find { parameter -> parameter.type == type }
+    }
+}
+
+class ScopeImpl(
+        val spec: TypeSpec?,
+        val typeName: TypeName,
+        val packageName: String,
+        val dependencies: Dependencies) {
+
+    companion object {
+
+        fun create(env: ProcessingEnvironment, graph: ResolvedGraph): List<ScopeImpl> {
+            return ScopeImplsFactory.create(env, graph)
+        }
+    }
+}
+
+private class ScopeImplFactory(
+        private val env: ProcessingEnvironment,
+        private val graph: ResolvedGraph,
+        private val scope: Scope,
+        private val childImpls: List<ChildImpl>) {
+
+    private val scopeTypeName = scope.clazz.typeName
+    private val scopeImplTypeName = scopeImplName(scopeTypeName)
+    private val packageName = scopeImplTypeName.packageName()
+
+    fun create(): ScopeImpl {
+        val dependencies = Dependencies.create(graph, scope, scopeImplTypeName)
+        if (alreadyGenerated()) {
+            return ScopeImpl(null, scopeImplTypeName, packageName, dependencies)
+        }
+
+        val objectsImpl = ObjectsImpl.create(env, scope, scopeImplTypeName)
+        val module = Module.create(scope, objectsImpl, scopeImplTypeName)
+        val component = Component.create(graph, scope, dependencies, module, childImpls, scopeTypeName, scopeImplTypeName)
+
+        val componentField = componentField(component)
+
+        val typeSpec = TypeSpec.classBuilder(scopeImplTypeName)
+        typeSpec.addAnnotation(scopeImplAnnotation(scope, dependencies))
+        typeSpec.addModifiers(Modifier.PUBLIC)
+
+        typeSpec.addSuperinterface(scopeTypeName)
+        typeSpec.addField(componentField)
+        typeSpec.addMethod(constructor(componentField, dependencies, component, scopeImplTypeName))
+        alternateConstructor(dependencies)?.let { typeSpec.addMethod(it) }
+        typeSpec.addMethods(childMethodImpls(component, componentField))
+        typeSpec.addMethods(accessMethodImpls(component, componentField))
+        typeSpec.addType(dependencies.spec)
+        typeSpec.addType(component.spec)
+        objectsImpl?.let { typeSpec.addType(it.spec) }
+        typeSpec.addType(module.spec)
+
+        return ScopeImpl(typeSpec.build(), scopeImplTypeName, packageName, dependencies)
+    }
+
+    private fun alreadyGenerated(): Boolean {
+        val scopeImplName = scopeImplTypeName.toString()
+        return env.elementUtils.getTypeElement(scopeImplName) != null
+    }
+
+    private fun scopeImplAnnotation(scope: Scope, dependencies: Dependencies): AnnotationSpec {
+        val builder = AnnotationSpec.builder(motif.ScopeImpl::class.java)
+        if (scope.childMethods.isEmpty()) {
+            builder.addMember("children", "{}")
+        } else {
+            scope.childMethods
+                    .forEach { childMethod ->
+                        val childScopeTypeName = childMethod.childScopeClass.typeName
+                        builder.addMember("children", "\$T.class", childScopeTypeName)
+                    }
+        }
+        return builder
+                .addMember("scope", "\$T.class", scopeTypeName)
+                .addMember("dependencies", "\$T.class", dependencies.typeName)
+                .build()
+    }
+
+    private fun componentField(component: Component): FieldSpec {
+        val fieldSpec = FieldSpec.builder(component.typeName, "component", Modifier.PRIVATE, Modifier.FINAL)
+        return fieldSpec.build()
+    }
+
+    private fun constructor(
+            componentField: FieldSpec,
+            dependencies: Dependencies,
+            component: Component,
+            scopeImplTypeName: ClassName): MethodSpec {
+        val dependenciesParam: ParameterSpec = ParameterSpec.builder(dependencies.typeName, "dependencies").build()
+        return MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(dependenciesParam)
+                .addStatement("this.\$N = \$T.builder()\n" +
+                        ".\$N(\$N)\n" +
+                        ".\$N(this)\n" +
+                        ".\$N()",
+                        componentField,
+                        daggerComponentName(scopeImplTypeName, component),
+                        component.builder.dependenciesMethod,
+                        dependenciesParam,
+                        component.builder.scopeMethod,
+                        component.builder.buildMethod)
+                .build()
+    }
+
+    private fun alternateConstructor(dependencies: Dependencies): MethodSpec? {
+        if (!dependencies.isEmpty()) {
+            return null
+        }
+        return MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .addStatement("this(new \$T() {})", dependencies.typeName)
+                .build()
+    }
+
+    private fun accessMethodImpls(
+            component: Component,
+            componentField: FieldSpec): List<MethodSpec> {
+        return scope.accessMethods.map { accessMethod ->
+            accessMethodImpl(component, componentField, accessMethod)
+        }
+    }
+
+    private fun accessMethodImpl(
+            component: Component,
+            componentField: FieldSpec,
+            accessMethod: AccessMethod): MethodSpec {
+        val componentMethod = component.getMethodSpec(accessMethod.returnType)
+        val methodSpec = overrideSpec(env, accessMethod.method)
+        methodSpec.addStatement("return \$N.\$N()", componentField, componentMethod)
+        return methodSpec.build()
+    }
+
+    private fun childMethodImpls(
+            component: Component,
+            componentField: FieldSpec): List<MethodSpec> {
+        return childImpls.map { childImpl -> childMethodImpl(component, componentField, childImpl) }
+    }
+
+    private fun childMethodImpl(
+            component: Component,
+            componentField: FieldSpec,
+            childImpl: ChildImpl): MethodSpec {
+        val child = childImpl.child
+        val methodSpec = overrideWithFinalParamsSpec(child.method.method)
+                .addModifiers(Modifier.PUBLIC)
+        val returnStatement: CodeBlock = if (childImpl.impl.dependencies.isEmpty()) {
+            CodeBlock.of("return new \$T()", childImpl.impl.typeName)
+        } else {
+            childMethodReturnStatement(component, componentField, childImpl)
+        }
+        methodSpec.addStatement(returnStatement)
+        return methodSpec.build()
+    }
+
+    private fun childMethodReturnStatement(
+            component: Component,
+            componentField: FieldSpec,
+            childImpl: ChildImpl): CodeBlock {
+        val childImplTypeName = childImpl.impl.typeName
+        val childDependencies = childImpl.impl.dependencies
+        val dependenciesTypeName = childDependencies.typeName
+
+        val dependenciesImplSpec = TypeSpec.anonymousClassBuilder("")
+        dependenciesImplSpec.addSuperinterface(dependenciesTypeName)
+
+        val childDependencyMethodImpls = childDependencyMethodImpls(component, componentField, childImpl, childDependencies)
+        dependenciesImplSpec.addMethods(childDependencyMethodImpls)
+
+        return CodeBlock.of("return new \$T(\$L)", childImplTypeName, dependenciesImplSpec.build())
+    }
+
+    private fun childDependencyMethodImpls(
+            component: Component,
+            componentField: FieldSpec,
+            childImpl: ChildImpl,
+            childDependencies: Dependencies): List<MethodSpec> {
+        return childDependencies.getMethods().map { childDependencyMethodImpl(component, componentField, childImpl, it) }
+    }
+
+    private fun childDependencyMethodImpl(
+            component: Component,
+            componentField: FieldSpec,
+            childImpl: ChildImpl,
+            method: Dependencies.Method): MethodSpec {
+        val abstractMethodSpec = method.methodSpec
+        val methodSpec = MethodSpec.methodBuilder(abstractMethodSpec.name)
+        methodSpec.addModifiers(Modifier.PUBLIC)
+        methodSpec.returns(abstractMethodSpec.returnType)
+        methodSpec.addAnnotation(Override::class.java)
+        val returnStatement = childDependencyMethodImplReturnStatement(component, componentField, childImpl, method)
+        methodSpec.addStatement(returnStatement)
+        return methodSpec.build()
+    }
+
+    private fun childDependencyMethodImplReturnStatement(
+            component: Component,
+            componentField: FieldSpec,
+            childImpl: ChildImpl,
+            method: Dependencies.Method): CodeBlock {
+        val returnType = method.type
+        val childMethodParameter = childImpl.getParameter(returnType)
+        return if (childMethodParameter == null) {
+            val componentMethodSpec = component.getMethodSpec(returnType)
+            return CodeBlock.of("return \$T.this.\$N.\$N()", scopeImplTypeName, componentField, componentMethodSpec)
+        } else {
+            CodeBlock.of("return \$N", childMethodParameter.parameter.name)
+        }
+    }
+
+    private fun scopeImplName(scopeClassName: ClassName): ClassName {
+        val prefix = scopeClassName.simpleNames().joinToString("")
+        return ClassName.get(scopeClassName.packageName(), "${prefix}Impl")
+    }
+
+    private fun daggerComponentName(scopeImplTypeName: ClassName, component: Component): ClassName {
+        val simpleName = component.typeName.simpleNames().joinToString("_")
+        return scopeImplTypeName.peerClass("Dagger$simpleName")
+    }
+}
+
+private class ScopeImplsFactory(
+        private val env: ProcessingEnvironment,
+        private val graph: ResolvedGraph) {
+
+    private val scopeImpls: MutableMap<Scope, ScopeImpl> = mutableMapOf()
+
+    fun getScopeImpls(): List<ScopeImpl> {
+        graph.scopes.forEach { getScopeImpl(it) }
+        return scopeImpls.values.toList()
+    }
+
+    private fun getScopeImpl(scope: Scope): ScopeImpl {
+        return scopeImpls.computeIfAbsent(scope) { computeScopeImpl(scope) }
+    }
+
+    private fun computeScopeImpl(scope: Scope): ScopeImpl {
+        val childImpls = graph.getChildren(scope)
+                .map { child ->
+                    val impl = getScopeImpl(child.scope)
+                    ChildImpl(child, impl)
+                }
+        return ScopeImplFactory(env, graph, scope, childImpls).create()
+    }
+
+    companion object {
+
+        fun create(env: ProcessingEnvironment, graph: ResolvedGraph): List<ScopeImpl> {
+            return ScopeImplsFactory(env, graph).getScopeImpls()
+        }
+    }
+}

--- a/compiler2/src/main/kotlin/motif/compiler/Util.kt
+++ b/compiler2/src/main/kotlin/motif/compiler/Util.kt
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import com.google.auto.common.AnnotationMirrors
+import com.squareup.javapoet.*
+import motif.ast.IrClass
+import motif.ast.IrMethod
+import motif.ast.IrType
+import motif.ast.compiler.CompilerAnnotation
+import motif.ast.compiler.CompilerMethod
+import motif.ast.compiler.CompilerType
+import motif.models.Type
+import javax.annotation.processing.ProcessingEnvironment
+import javax.lang.model.element.AnnotationMirror
+import javax.lang.model.element.Element
+import javax.lang.model.element.Modifier
+import javax.lang.model.element.TypeElement
+import javax.lang.model.type.*
+import javax.lang.model.util.SimpleElementVisitor8
+import javax.lang.model.util.SimpleTypeVisitor8
+
+fun overrideSpec(env: ProcessingEnvironment, method: IrMethod): MethodSpec.Builder {
+    val compilerMethod = method as CompilerMethod
+    return MethodSpec.overriding(compilerMethod.element, compilerMethod.owner, env.typeUtils)
+}
+
+fun overrideWithFinalParamsSpec(method: IrMethod): MethodSpec.Builder {
+    val builder = MethodSpec.methodBuilder(method.name)
+            .addAnnotation(Override::class.java)
+            .returns(method.returnType.typeName)
+
+    method.parameters
+            .map {
+                ParameterSpec.builder(it.type.typeName, it.name)
+                        .addModifiers(Modifier.FINAL)
+                        .build()
+            }
+            .forEach { builder.addParameter(it) }
+
+    return builder
+}
+
+fun methodSpec(nameScope: NameScope, type: Type): MethodSpec.Builder {
+    val name = nameScope.name(type)
+    val spec = MethodSpec.methodBuilder(name)
+    spec.returns(type.typeName)
+    type.qualifierSpec?.let { spec.addAnnotation(it) }
+    return spec
+}
+
+fun parameterSpec(nameScope: NameScope, type: Type): ParameterSpec {
+    val name = nameScope.name(type)
+    return parameterSpec(type, name)
+}
+
+fun parameterSpec(type: Type, name: String): ParameterSpec {
+    val spec = ParameterSpec.builder(type.typeName, name)
+    type.qualifierSpec?.let { spec.addAnnotation(it) }
+    return spec.build()
+}
+
+val IrClass.typeName: ClassName
+    get() = type.typeName
+
+val IrType.typeName: ClassName
+    get() = ClassName.get((this as CompilerType).mirror) as ClassName
+
+val Type.mirror: TypeMirror
+    get() = (type as CompilerType).mirror
+
+val Type.qualifierMirror: AnnotationMirror?
+    get() = (qualifier as? CompilerAnnotation)?.mirror
+
+val Type.typeName: TypeName
+    get() = ClassName.get(mirror)
+
+val Type.qualifierSpec: AnnotationSpec?
+    get() = qualifierMirror?.let { AnnotationSpec.get(it) }
+
+class NameScope {
+
+    private val names = UniqueNameSet()
+
+    fun name(type: Type): String {
+        return names.unique(Names.safeName(type.mirror, type.qualifierMirror))
+    }
+}
+
+private class UniqueNameSet {
+
+    private val used: MutableSet<String> = mutableSetOf()
+
+    fun unique(base: String): String {
+        var name = base
+        var i = 2
+        while (!used.add(name)) {
+            name = "$base${i++}"
+        }
+        return name
+    }
+}
+
+
+class Names {
+
+    companion object {
+
+        @JvmStatic
+        fun safeName(typeMirror: TypeMirror, annnotation: AnnotationMirror?): String {
+            var name = NameVisitor.visit(typeMirror)
+            val annotationString = annnotation?.let(this::annotationString) ?: ""
+            name = "$annotationString$name".decapitalize()
+            if (name in KEYWORDS) {
+                name += "_"
+            }
+            return name
+        }
+
+        private fun annotationString(annnotation: AnnotationMirror): String {
+            return if (annnotation.annotationType.toString() == "javax.inject.Named") {
+                AnnotationMirrors.getAnnotationValue(annnotation, "value").value.toString()
+            } else {
+                annnotation.annotationType.asElement().simpleName.toString()
+            }
+        }
+    }
+}
+
+private object NameVisitor : SimpleTypeVisitor8<String, Void>() {
+
+    override fun visitPrimitive(t: PrimitiveType, p: Void?): String {
+        return when (t.kind) {
+            TypeKind.BOOLEAN -> "Boolean"
+            TypeKind.BYTE -> "Byte"
+            TypeKind.SHORT -> "Short"
+            TypeKind.INT -> "Int"
+            TypeKind.LONG -> "Long"
+            TypeKind.CHAR -> "Char"
+            TypeKind.FLOAT -> "Float"
+            TypeKind.DOUBLE -> "Double"
+            else -> throw IllegalStateException()
+        }
+    }
+
+    override fun visitDeclared(t: DeclaredType, p: Void?): String {
+        val simpleName = t.asElement().simpleName.toString()
+        val enclosingElementString = t.asElement().enclosingElement.accept(object : SimpleElementVisitor8<String, Void?>() {
+
+            override fun defaultAction(e: Element?, p: Void?): String {
+                return ""
+            }
+
+            override fun visitType(e: TypeElement, p: Void?): String {
+                return e.simpleName.toString()
+            }
+        }, null)
+
+        val rawString = "$enclosingElementString$simpleName"
+
+        if (t.typeArguments.isEmpty()) {
+            return rawString
+        }
+
+        val typeArgumentString = t.typeArguments
+                .map { visit(it) }
+                .joinToString("")
+
+        return "$typeArgumentString$rawString"
+    }
+
+    override fun visitError(t: ErrorType, p: Void?): String {
+        return visitDeclared(t, p)
+    }
+
+    override fun visitArray(t: ArrayType, p: Void?): String {
+        return visit(t.componentType) + "Array"
+    }
+
+    override fun visitTypeVariable(t: TypeVariable, p: Void?): String {
+        return t.asElement().simpleName.toString().capitalize()
+    }
+
+    override fun visitWildcard(t: WildcardType, p: Void?): String {
+        t.extendsBound?.let { return visit(it) }
+        t.superBound?.let { return visit(it) }
+        return ""
+    }
+
+    override fun visitNoType(t: NoType, p: Void?): String {
+        return if (t.kind == TypeKind.VOID) "Void" else super.visitUnknown(t, p)
+    }
+
+    override fun defaultAction(e: TypeMirror, p: Void?): String {
+        throw IllegalArgumentException("Unexpected type mirror: $e")
+    }
+}
+
+private val KEYWORDS = setOf(
+        "abstract",
+        "continue",
+        "for",
+        "new",
+        "switch",
+        "assert",
+        "default",
+        "goto",
+        "package",
+        "synchronized",
+        "boolean",
+        "do",
+        "if",
+        "private",
+        "this",
+        "break",
+        "double",
+        "implements",
+        "protected",
+        "throw",
+        "byte",
+        "else",
+        "import",
+        "public",
+        "throws",
+        "case",
+        "enum",
+        "instanceof",
+        "return",
+        "transient",
+        "catch",
+        "extends",
+        "int",
+        "short",
+        "try",
+        "char",
+        "final",
+        "interface",
+        "static",
+        "void",
+        "class",
+        "finally",
+        "long",
+        "strictfp",
+        "volatile",
+        "const",
+        "float",
+        "native",
+        "super",
+        "while")

--- a/compiler2/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/compiler2/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,2 @@
+motif.compiler.Processor
+dagger.internal.codegen.ComponentProcessor

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,6 +34,7 @@ pluginManagement {
 rootProject.name = 'motif'
 include 'lib'
 include 'compiler'
+include 'compiler2'
 include 'compiler-ast'
 include 'samples:sample'
 include 'samples:sample-lib'


### PR DESCRIPTION
This is the top-level module for the Motif annotation processor. It contains the `Processor` itself and all code generation logic. The module will also run the Dagger annotation processor.

Tests will be added in a following PR.