### PR TITLE
Add new Motif compiler test harness

### DIFF
--- a/compiler2/src/test/java/com/google/testing/compile/MotifTestCompiler.java
+++ b/compiler2/src/test/java/com/google/testing/compile/MotifTestCompiler.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.testing.compile;
+
+import com.google.common.collect.ImmutableList;
+import dagger.internal.codegen.ComponentProcessor;
+
+import javax.annotation.Nullable;
+import javax.annotation.processing.Processor;
+import javax.tools.*;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class MotifTestCompiler {
+
+    private final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+    public Compilation compile(
+            @Nullable File classpathDir,
+            @Nullable File outDir,
+            @Nullable Processor motifProcessor,
+            File dir) throws IOException {
+        List<JavaFileObject> files = javaFileObjects(dir);
+        DiagnosticCollector<JavaFileObject> diagnosticCollector = new DiagnosticCollector<>();
+
+        StandardJavaFileManager fileManager = ToolProvider.getSystemJavaCompiler()
+                .getStandardFileManager(diagnosticCollector, Locale.getDefault(), UTF_8);
+        if (outDir == null) {
+            fileManager = new InMemoryJavaFileManager(fileManager);
+        }
+        CollectingFileManager collectingFileManager = new CollectingFileManager(fileManager);
+
+        ImmutableList.Builder<String> optionsBuilder = ImmutableList.builder();
+        if (classpathDir != null) {
+            String currentClasspath = System.getProperty("java.class.path");
+            String newClasspath = classpathDir + ":" + currentClasspath;
+            optionsBuilder.add("-classpath", newClasspath);
+        }
+        if (outDir != null) {
+            optionsBuilder.add("-d", outDir.getAbsolutePath());
+        }
+
+        JavaCompiler.CompilationTask task = compiler.getTask(
+                null,
+                collectingFileManager,
+                diagnosticCollector,
+                optionsBuilder.build(),
+                Collections.emptyList(),
+                files);
+
+        ImmutableList.Builder<Processor> processorsBuilder = ImmutableList.builder();
+        if (motifProcessor != null) {
+            processorsBuilder.add(motifProcessor);
+        }
+        processorsBuilder.add(new ComponentProcessor());
+
+        task.setProcessors(processorsBuilder.build());
+        boolean succeeded = task.call();
+        return new Compilation(
+                Compiler.javac(),
+                files,
+                succeeded,
+                diagnosticCollector.getDiagnostics(),
+                collectingFileManager.getOutputFiles());
+    }
+
+    private class CollectingFileManager extends ForwardingJavaFileManager<JavaFileManager> {
+
+        private final Set<JavaFileObject> outputFiles = new HashSet<>();
+
+        public CollectingFileManager(JavaFileManager fileManager) {
+            super(fileManager);
+        }
+
+        public Set<JavaFileObject> getOutputFiles() {
+            return outputFiles;
+        }
+
+        @Override
+        public JavaFileObject getJavaFileForOutput(Location location, String className, JavaFileObject.Kind kind, FileObject sibling) throws IOException {
+            JavaFileObject javaFile = super.getJavaFileForOutput(location, className, kind, sibling);
+            outputFiles.add(javaFile);
+            return javaFile;
+        }
+    }
+
+    // TODO Remove Test.java filter after deletion of old test code.
+    private static List<JavaFileObject> javaFileObjects(File dir) throws IOException {
+        boolean skipTest = new File(dir, "ERROR.txt").exists();
+        return Files.walk(dir.toPath())
+                .map(Path::toFile)
+                .filter(file -> !file.isDirectory()
+                        && file.getName().endsWith(".java")
+                        && !file.getName().endsWith("ScopeImpl.java")
+                        && (!skipTest || !file.getName().equals("Test.java")))
+                .map(file -> {
+                    try {
+                        return JavaFileObjects.forResource(file.toURI().toURL());
+                    } catch (MalformedURLException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/compiler2/src/test/java/license/LicenseTest.kt
+++ b/compiler2/src/test/java/license/LicenseTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package license
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class LicenseTest {
+
+    @Rule @JvmField val temporaryFolder = TemporaryFolder()
+
+    private val licenseText = """
+        /*
+         * Copyright (c) 2018 Uber Technologies, Inc.
+         *
+         * Licensed under the Apache License, Version 2.0 (the "License");
+         * you may not use this file except in compliance with the License.
+         * You may obtain a copy of the License at
+         *
+         *      http://www.apache.org/licenses/LICENSE-2.0
+         *
+         * Unless required by applicable law or agreed to in writing, software
+         * distributed under the License is distributed on an "AS IS" BASIS,
+         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+         * See the License for the specific language governing permissions and
+         * limitations under the License.
+         */
+    """.trimIndent()
+
+    @Test
+    fun test() {
+        val srcDirs = File("..").walk()
+                .filter { file ->
+                    file.name == "src"
+                            && file.isDirectory
+                            && file.resolveSibling("build.gradle").exists()
+                }
+        val missingLicenses = srcDirs.flatMap { srcDir -> srcDir.walk() }
+                .filter { it.extension == "java" || it.extension == "kt" }
+                .filter { !it.ensureLicense() }
+                .toList()
+        assertThat(missingLicenses).isEmpty()
+    }
+
+    private fun File.ensureLicense(): Boolean {
+        val hasLicense = useLines {
+            it.take(3).find { "Copyright" in it } != null
+        }
+
+        if (hasLicense) {
+            return true
+        }
+
+        val tmpFile = temporaryFolder.newFile()
+        tmpFile.writer().use { out ->
+            out.write(licenseText)
+            out.appendln()
+            reader().copyTo(out)
+        }
+        tmpFile.renameTo(this)
+        return false
+    }
+}

--- a/compiler2/src/test/java/motif/compiler/CompilationClassLoader.java
+++ b/compiler2/src/test/java/motif/compiler/CompilationClassLoader.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler;
+
+import com.google.common.io.ByteStreams;
+import com.google.testing.compile.Compilation;
+
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.*;
+
+import static javax.tools.StandardLocation.CLASS_OUTPUT;
+
+public class CompilationClassLoader extends ClassLoader {
+
+    private final Compilation compilation;
+
+    public CompilationClassLoader(Compilation compilation) {
+        this(ClassLoader.getSystemClassLoader(), compilation);
+    }
+
+    public CompilationClassLoader(ClassLoader parent, Compilation compilation) {
+        super(parent);
+        this.compilation = compilation;
+    }
+
+    @Override
+    protected Class<?> findClass(final String name) throws ClassNotFoundException {
+        String path = name.replace(".", "/").concat(".class");
+        JavaFileObject generatedClass = compilation.generatedFile(CLASS_OUTPUT, path).orElse(null);
+        if (generatedClass == null) {
+            return super.findClass(name);
+        }
+        try (InputStream is = generatedClass.openInputStream()) {
+            byte[] classBytes = ByteStreams.toByteArray(is);
+            return defineClass(name, classBytes, 0, classBytes.length);
+        } catch (IOException e) {
+            throw new ClassNotFoundException(name, e);
+        }
+    }
+
+    @Override
+    protected URL findResource(String name) {
+        JavaFileObject generatedResource = compilation.generatedFile(CLASS_OUTPUT, name).orElse(null);
+        if (generatedResource == null) {
+            return super.findResource(name);
+        }
+        try {
+            URI uri = generatedResource.toUri();
+            return new URL("compilation", "", -1, uri.getPath(), new URLStreamHandler() {
+                @Override
+                protected URLConnection openConnection(URL u) {
+                    return new URLConnection(u) {
+                        @Override
+                        public void connect() {
+                            connected = true;
+                        }
+
+                        @Override
+                        public InputStream getInputStream() throws IOException {
+                            return generatedResource.openInputStream();
+                        }
+                    };
+                }
+            });
+        } catch (MalformedURLException e) {
+            // Should never happen, since no validation is performed when stream handler is provided.
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/compiler2/src/test/java/motif/compiler/NamesTest.java
+++ b/compiler2/src/test/java/motif/compiler/NamesTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.CompilationSubject;
+import com.google.testing.compile.JavaFileObjects;
+import dagger.shaded.auto.common.AnnotationMirrors;
+import motif.compiler.Names;
+import org.junit.Test;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.inject.Qualifier;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+
+public class NamesTest {
+
+    @Test
+    public void basic() {
+        String name = getSafeName("java.util.HashMap");
+        assertThat(name).isEqualTo("hashMap");
+    }
+
+    @Test
+    public void typeArgument() {
+        String name = getSafeName("java.util.HashMap<String, Integer>");
+        assertThat(name).isEqualTo("stringIntegerHashMap");
+    }
+
+    @Test
+    public void wildcard() {
+        String name = getSafeName("java.util.HashMap<? extends String, ? super Integer>");
+        assertThat(name).isEqualTo("stringIntegerHashMap");
+    }
+
+    @Test
+    public void typeVariable() {
+        String name = getSafeName("java.util.HashMap<String, A>");
+        assertThat(name).isEqualTo("stringAHashMap");
+    }
+
+    @Test
+    public void nested() {
+        String name = getSafeName("java.util.HashMap<java.util.HashMap<String, Integer>, Integer>");
+        assertThat(name).isEqualTo("stringIntegerHashMapIntegerHashMap");
+    }
+
+    @Test
+    public void innerClass() {
+        String name = getSafeName("java.util.Map.Entry<String, Integer>");
+        assertThat(name).isEqualTo("stringIntegerMapEntry");
+    }
+
+    @Test
+    public void keyword() {
+        String name = getSafeName("java.lang.Boolean");
+        assertThat(name).isEqualTo("boolean_");
+    }
+
+    @Test
+    public void named() {
+        String name = getSafeName("@javax.inject.Named(\"Foo\") String");
+        assertThat(name).isEqualTo("fooString");
+    }
+
+    @Test
+    public void customQualifier() {
+        String name = getSafeName("@Foo String");
+        assertThat(name).isEqualTo("fooString");
+    }
+
+    private static String getSafeName(String classString) {
+        SafeNameProcessor processor = new SafeNameProcessor();
+        Compilation compilation = javac()
+                .withProcessors(processor)
+                .compile(JavaFileObjects.forSourceLines(
+                        "test.Test",
+                        "package test;",
+                        "@javax.inject.Qualifier @interface Foo {}",
+                        "class Test<A extends String> {",
+                        classString + " test() { return null; }",
+                        "}"
+                ));
+        CompilationSubject.assertThat(compilation).succeeded();
+        return processor.getSafeName();
+    }
+
+    private static class SafeNameProcessor extends AbstractProcessor {
+
+        private String safeName;
+
+        String getSafeName() {
+            assertThat(safeName).isNotNull();
+            return safeName;
+        }
+
+        @Override
+        public Set<String> getSupportedAnnotationTypes() {
+            return ImmutableSet.of("*");
+        }
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            if (roundEnv.processingOver()) {
+                return true;
+            }
+
+            TypeElement typeElement = processingEnv.getElementUtils().getTypeElement("test.Test");
+            assertThat(typeElement).isNotNull();
+
+            List<ExecutableElement> methods = ElementFilter.methodsIn(typeElement.getEnclosedElements());
+            assertThat(methods).isNotEmpty();
+
+            ExecutableElement testMethod = methods.get(0);
+
+            TypeMirror returnType = testMethod.getReturnType();
+            Collection<? extends AnnotationMirror> qualifiers = AnnotationMirrors.getAnnotatedAnnotations(testMethod, Qualifier.class);
+            AnnotationMirror qualifier = qualifiers.isEmpty() ? null : qualifiers.iterator().next();
+            safeName = Names.safeName(returnType, qualifier);
+
+            return true;
+        }
+    }
+}

--- a/compiler2/src/test/java/motif/compiler/TestHarness.java
+++ b/compiler2/src/test/java/motif/compiler/TestHarness.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler;
+
+import com.google.common.io.Files;
+import com.google.common.truth.Truth;
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.MotifTestCompiler;
+import motif.core.ResolvedGraph;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+
+@RunWith(Parameterized.class)
+public class TestHarness {
+
+    @Parameterized.Parameters(name = "{2}")
+    public static Collection<Object[]> data() {
+        File sourceRoot = new File("../tests/src/main/java/");
+        File testCaseRoot = new File(sourceRoot, "testcases");
+        File externalRoot = new File(sourceRoot, "external");
+        File[] testCaseDirs = testCaseRoot.listFiles(TestHarness::isTestDir);
+        if (testCaseDirs == null) throw new IllegalStateException("Could not find test case directories: " + testCaseRoot);
+        return Arrays.stream(testCaseDirs)
+                .map(file -> {
+                    File externalDir = new File(externalRoot, file.getName());
+                    return new Object[]{file.getAbsoluteFile(), externalDir, file.getName()};
+                })
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isTestDir(File file) {
+        String filename = file.getName();
+        return file.isDirectory()
+                && file.listFiles().length > 0
+                && (filename.startsWith("T") || filename.startsWith("E"));
+    }
+
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private final MotifTestCompiler compiler = new MotifTestCompiler();
+
+    private final File testCaseDir;
+    private final File externalDir;
+    private final String testClassName;
+    private final File humanReadableFile;
+    private final boolean isErrorTest;
+
+    private File externalOutputDir;
+
+    @SuppressWarnings("unused")
+    public TestHarness(File testCaseDir, File externalDir, String testName) {
+        this.testCaseDir = testCaseDir;
+        this.externalDir = externalDir;
+        this.testClassName = "testcases." + testName + ".Test";
+        this.humanReadableFile = new File(testCaseDir, "ERROR.txt");
+        this.isErrorTest = testName.startsWith("E");
+    }
+
+    @Test
+    public void test() throws Throwable {
+        File[] externalDirContents = externalDir.listFiles();
+        boolean hasExternalSources = externalDirContents != null && externalDirContents.length > 0;
+        externalOutputDir = hasExternalSources ? temporaryFolder.newFolder() : null;
+
+        if (externalOutputDir != null) {
+            boolean shouldProcess = !new File(externalDir, "DO_NOT_PROCESS").exists();
+            Compilation externalCompilation = compiler.compile(
+                    null,
+                    externalOutputDir,
+                    shouldProcess ? new Processor() : null,
+                    externalDir);
+            assertThat(externalCompilation).succeeded();
+        }
+
+        Processor processor = new Processor();
+        Compilation compilation = compiler.compile(
+                externalOutputDir,
+                null,
+                processor,
+                testCaseDir);
+
+        if (isErrorTest) {
+            runErrorTest(compilation, processor.graph);
+        } else {
+            runSuccessTest(compilation);
+        }
+    }
+
+    private void runErrorTest(Compilation compilation, ResolvedGraph graph) throws IOException {
+        assertThat(compilation).failed();
+
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.diagnostics().asList();
+        Truth.assertThat(diagnostics).hasSize(1);
+        Diagnostic diagnostic = diagnostics.get(0);
+
+        String expectedHumanReadableString = getExistingHumanReadableString();
+        String actualHumanReadableString = getActualHumanReadableString(diagnostic);
+
+        if (!expectedHumanReadableString.equals(actualHumanReadableString)) {
+            try (BufferedWriter out = new BufferedWriter(new FileWriter(humanReadableFile))) {
+                out.write(actualHumanReadableString);
+            }
+            Truth.assertWithMessage("Error message has changed. The ERROR.txt file has been " +
+                    "automatically updated by this test:\n" +
+                    "  1. Verify that the changes are correct.\n" +
+                    "  2. Commit the changes to source control.\n").fail();
+        }
+    }
+
+    private void runSuccessTest(Compilation compilation) throws Throwable {
+        assertThat(compilation).succeeded();
+        Class<?> testClass = loadTestClass(compilation);
+
+        if (testClass.getAnnotation(Ignore.class) != null) {
+            return;
+        }
+
+        assertThat(compilation).succeeded();
+
+        try {
+            testClass.getField("loadedClasses");
+            // Skip buck loaded classes test. No longer supported.
+            // TODO Remove T031 after old compiler is removed.
+            return;
+        } catch (NoSuchFieldException ignore) {}
+
+        try {
+            testClass.getMethod("run").invoke(null);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    private String getActualHumanReadableString(Diagnostic diagnostic) {
+        String message = diagnostic.getMessage(Locale.getDefault());
+        String header =
+                "########################################################################\n" +
+                "#                                                                      #\n" +
+                "# This file is auto-generated by running the Motif compiler tests and  #\n" +
+                "# serves both as validation of error correctness and as a record of    #\n" +
+                "# the current compiler error output.                                   #\n" +
+                "#                                                                      #\n" +
+                "# - Do not edit manually.                                              #\n" +
+                "# - Commit changes to source control.                                  #\n" +
+                "# - Since this file is autogenerated, code review changes carefully to #\n" +
+                "#   ensure correctness.                                                #\n" +
+                "#                                                                      #\n" +
+                "########################################################################\n";
+        return header + message + "\n";
+    }
+
+    private String getExistingHumanReadableString() throws IOException {
+        if (humanReadableFile.exists()) {
+            return Files.asCharSource(humanReadableFile, Charset.defaultCharset()).read();
+        } else {
+            return "";
+        }
+    }
+
+    private Class<?> loadTestClass(Compilation compilation) throws ClassNotFoundException, MalformedURLException {
+        ClassLoader classLoader;
+        if (externalOutputDir == null) {
+            classLoader = new CompilationClassLoader(compilation);
+        } else {
+            ClassLoader externalClassLoader = new URLClassLoader(new URL[]{externalOutputDir.toURI().toURL()});
+            classLoader = new CompilationClassLoader(externalClassLoader, compilation);
+        }
+        return classLoader.loadClass(testClassName);
+    }
+}


### PR DESCRIPTION
This test harness runs all of the existing integration tests in the `:tests` module. For error cases, instead of running the existing `Test.java` code, this new harness ensures that the output matches the content of the ERROR.txt file that exists in the test case directory.