### PR TITLE
Defer processing of elements that depend on generated code.

### DIFF
--- a/tests/compiler/src/main/java/motif/stubcompiler/StubProcessor.kt
+++ b/tests/compiler/src/main/java/motif/stubcompiler/StubProcessor.kt
@@ -29,6 +29,7 @@ import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.ElementKind
+import javax.lang.model.element.Modifier
 import javax.lang.model.element.TypeElement
 import javax.lang.model.type.DeclaredType
 
@@ -63,6 +64,7 @@ class StubProcessor : AbstractProcessor() {
         }
         val builder = TypeSpec.classBuilder(scopeImplClassName)
                 .addMethod(MethodSpec.constructorBuilder().build())
+                .addType(TypeSpec.interfaceBuilder("Dependencies").build())
 
         if (scopeType.asElement().kind == ElementKind.INTERFACE) {
             builder.addSuperinterface(scopeClassName)

--- a/tests/src/main/java/testcases/T056_deferred_rounds/Child.java
+++ b/tests/src/main/java/testcases/T056_deferred_rounds/Child.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T056_deferred_rounds;
+
+@motif.Scope
+public interface Child {
+
+    String string();
+}

--- a/tests/src/main/java/testcases/T056_deferred_rounds/Scope.java
+++ b/tests/src/main/java/testcases/T056_deferred_rounds/Scope.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T056_deferred_rounds;
+
+@motif.Scope
+public interface Scope extends ChildImpl.Dependencies {
+
+    @motif.Objects
+    class Objects {
+
+        String string() {
+            return "s";
+        }
+    }
+}

--- a/tests/src/main/java/testcases/T056_deferred_rounds/Test.java
+++ b/tests/src/main/java/testcases/T056_deferred_rounds/Test.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T056_deferred_rounds;
+
+public class Test {
+
+    public static void run() {
+        new ScopeImpl();
+    }
+}


### PR DESCRIPTION
Previously, Motif's annotation processor would fail to recognize code generated superinterfaces/superclasses. Leverage BasicAnnotationProcessor to defer processing of elements that depend on generated code. Only add test for immediate superinterfaces for now. Once google/auto#733 lands and is deployed we'll update to the newest version of google/auto and add tests for grandparent superinterfaces.