### PR TITLE
Handle generic child method parameters.

### DIFF
--- a/compiler2/src/main/kotlin/motif/compiler/Util.kt
+++ b/compiler2/src/main/kotlin/motif/compiler/Util.kt
@@ -74,10 +74,10 @@ fun parameterSpec(type: Type, name: String): ParameterSpec {
 }
 
 val IrClass.typeName: ClassName
-    get() = type.typeName
+    get() = type.typeName as ClassName
 
-val IrType.typeName: ClassName
-    get() = ClassName.get((this as CompilerType).mirror) as ClassName
+val IrType.typeName: TypeName
+    get() = ClassName.get((this as CompilerType).mirror)
 
 val Type.mirror: TypeMirror
     get() = (type as CompilerType).mirror

--- a/tests/src/main/java/testcases/T057_generic_dynamic_dependency/Child.java
+++ b/tests/src/main/java/testcases/T057_generic_dynamic_dependency/Child.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T057_generic_dynamic_dependency;
+
+import motif.Scope;
+
+import java.util.function.Supplier;
+
+@Scope
+public interface Child {
+
+    String string();
+
+    @motif.Objects
+    class Objects {
+
+        String string(Supplier<String> supplier) {
+            return supplier.get();
+        }
+    }
+}

--- a/tests/src/main/java/testcases/T057_generic_dynamic_dependency/Scope.java
+++ b/tests/src/main/java/testcases/T057_generic_dynamic_dependency/Scope.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T057_generic_dynamic_dependency;
+
+import java.util.function.Supplier;
+
+@motif.Scope
+public interface Scope {
+
+    Child child(Supplier<String> parent);
+
+    @motif.Dependencies
+    interface Dependencies {}
+}

--- a/tests/src/main/java/testcases/T057_generic_dynamic_dependency/Test.java
+++ b/tests/src/main/java/testcases/T057_generic_dynamic_dependency/Test.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases.T057_generic_dynamic_dependency;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class Test {
+
+    public static void run() {
+        Scope scope = new ScopeImpl();
+        Child child = scope.child(() -> "s");
+        assertThat(child.string()).isEqualTo("s");
+    }
+}


### PR DESCRIPTION
New annotation processor would previously crash with generic child method parameters.
