### PR TITLE
Tweak old codegen to match new implementation

### DIFF
--- a/compiler/src/main/java/motif/compiler/codegen/ModuleFactory.kt
+++ b/compiler/src/main/java/motif/compiler/codegen/ModuleFactory.kt
@@ -96,7 +96,7 @@ class ModuleFactory(
     }
 
     private fun MethodSpec.Builder.build(method: SpreadMethod): MethodSpec {
-        val spreadParameter = nameScope { method.source.parameterSpec() }
+        val spreadParameter = method.source.parameterSpec("source")
         addParameter(spreadParameter)
         addStatement("return \$N.\$N()", spreadParameter, method.cir.name)
         return build()


### PR DESCRIPTION
This PR makes a few tweaks to the old codegen logic to match the new codegen exactly. After these changes, the old and new compiler generate exactly the same code in the Uber monorepo.

* Do not include qualifiers on overidden child dependencies methods.
* Source `@Provides` method parameter is always named "source".
* Use default constructor for child Scope construction if possible.