### PR TITLE
Renames Child in ScopeGraph to ScopeEdge.

### DIFF
--- a/compiler2/src/main/kotlin/motif/compiler/Component.kt
+++ b/compiler2/src/main/kotlin/motif/compiler/Component.kt
@@ -70,7 +70,7 @@ class Component private constructor(
                 children: List<ChildImpl>): SortedMap<Type, MethodSpec> {
             val nameScope = NameScope()
             val requiredTypes = (scope.accessMethods.map { it.returnType } +
-                    children.flatMap { childImpl -> graph.getChildUnsatisfied(childImpl.child).map { it.type } })
+                    children.flatMap { childImpl -> graph.getChildUnsatisfied(childImpl.childEdge).map { it.type } })
                     .toSet()
             return requiredTypes.associate { type ->
                 val methodSpec = methodSpec(nameScope, type)

--- a/core2/src/main/kotlin/motif/core/ScopeGraph.kt
+++ b/core2/src/main/kotlin/motif/core/ScopeGraph.kt
@@ -19,41 +19,41 @@ import motif.ast.IrType
 import motif.models.ChildMethod
 import motif.models.Scope
 
-class Child(val parent: Scope, val method: ChildMethod, val scope: Scope)
+class ScopeEdge(val parent: Scope, val child: Scope, val method: ChildMethod)
 
 /**
  * Graph of [Scopes][Scope] as defined by [Scope.childMethods]. Throws an [IllegalStateException] if any of a
- * Scope's child Scopes does not exist in the initial list of Scopes.
+ * Scope's childEdge Scopes does not exist in the initial list of Scopes.
  */
 internal class ScopeGraph private constructor(val scopes: List<Scope>) {
 
     private val scopeMap: Map<IrType, Scope> = scopes.associateBy { it.clazz.type }
-    private val children: Map<Scope, List<Child>> = scopes.associate { scope -> scope to createChildren(scope) }
-    private val parents: Map<Scope, List<Child>> = {
-        val mapping = children.values.flatten().groupBy { it.scope }
+    private val childEdges: Map<Scope, List<ScopeEdge>> = scopes.associate { scope -> scope to createChildren(scope) }
+    private val parentEdges: Map<Scope, List<ScopeEdge>> = {
+        val mapping = childEdges.values.flatten().groupBy { it.child }
         scopes.associateWith { mapping[it] ?: emptyList() }
     }()
 
-    val roots: List<Scope> = parents.filter { it.value.isEmpty() }.map { it.key }
+    val roots: List<Scope> = parentEdges.filter { it.value.isEmpty() }.map { it.key }
 
     val scopeCycleError: ScopeCycleError? = calculateCycle()
 
-    fun getChildren(scope: Scope): List<Child> {
-        return children[scope] ?: throw NullPointerException("Scope not found: ${scope.qualifiedName}")
+    fun getChildEdges(scope: Scope): List<ScopeEdge> {
+        return childEdges[scope] ?: throw NullPointerException("Scope not found: ${scope.qualifiedName}")
     }
 
-    private fun createChildren(scope: Scope): List<Child> {
+    private fun createChildren(scope: Scope): List<ScopeEdge> {
         return scope.childMethods.map { method ->
             val childScope = scopeMap[method.childScopeClass.type]
                     ?: throw IllegalStateException("Scope not found: ${scope.qualifiedName}")
-            Child(scope, method, childScope)
+            ScopeEdge(scope, childScope, method)
         }
     }
 
     private fun calculateCycle(): ScopeCycleError? {
         // Sort for stable tests
         val sortedScopes = scopes.sortedBy { it.qualifiedName }
-        val cycle = Cycle.find(sortedScopes) { scope -> getChildren(scope).map { it.scope } } ?: return null
+        val cycle = Cycle.find(sortedScopes) { scope -> getChildEdges(scope).map { it.child } } ?: return null
         return ScopeCycleError(cycle.path)
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Motif. Before pressing the "Create Pull Request" button, please consider the following
points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
The field  `private val parents: Map<Scope, List<Child>> ` in `ScopeGraph` stores the parents of a Scope while the class name `Child` could be ambiguous. Renaming `Child` class to `ScopeEdge` so that the name explicitly describes the responsibilities of the class `ScopeEdge` - to represent the relationships between parent and child scopes and to store additional information such as `child methods`.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
