### PR TITLE
Fixes to superclass implementation

### DIFF
--- a/ast/src/main/kotlin/motif/ast/IrClass.kt
+++ b/ast/src/main/kotlin/motif/ast/IrClass.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KClass
 interface IrClass : IrAnnotated, IrHasModifiers {
 
     val type: IrType
-    val superclass: IrType
+    val superclass: IrType?
     val typeArguments: List<IrType>
     val kind: Kind
     val methods: List<IrMethod>

--- a/intellij/ast/src/main/kotlin/motif/ast/intellij/IntelliJClass.kt
+++ b/intellij/ast/src/main/kotlin/motif/ast/intellij/IntelliJClass.kt
@@ -36,7 +36,10 @@ class IntelliJClass(
 
     override val type: IrType by lazy { IntelliJType(project, psiClassType) }
 
-    override val superclass: IrType by lazy { IntelliJType(project, psiClass.superClassType as PsiClassType) }
+    override val superclass: IrType? by lazy {
+        val superType = psiClassType.superTypes.firstOrNull() ?: return@lazy null
+        IntelliJType(project, superType)
+    }
 
     override val typeArguments: List<IrType> by lazy {
         psiClassType.typeArguments()


### PR DESCRIPTION
* Propagate generics information across multiple parent classes
* Handle `java.lang.Object`
