### PR TITLE
Add GeneratedClass abstraction to codegen logic.

### DIFF
--- a/compiler/src/main/kotlin/motif/compiler/CodeGenerator.kt
+++ b/compiler/src/main/kotlin/motif/compiler/CodeGenerator.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.TypeSpec
+import motif.core.ResolvedGraph
+import motif.models.Scope
+import javax.annotation.processing.ProcessingEnvironment
+
+interface GeneratedClass {
+
+    val packageName: String
+    val spec: TypeSpec
+}
+
+class CodeGenerator(
+        private val env: ProcessingEnvironment,
+        private val graph: ResolvedGraph) {
+
+    private val dependencies = mutableMapOf<Scope, Dependencies>()
+    private val implTypeNames = mutableMapOf<Scope, ClassName>()
+
+    private fun getScopeImpls(): List<ScopeImpl> {
+        return graph.scopes
+                .filter { scope ->
+                    val scopeImplName = getImplTypeName(scope)
+                    env.elementUtils.getTypeElement(scopeImplName.toString()) == null
+                }
+                .map { scope ->
+                    val childEdges = graph.getChildEdges(scope)
+                            .map { childEdge ->
+                                val childImplTypeName = getImplTypeName(childEdge.child)
+                                val dependencies = getDependencies(childEdge.child)
+                                ChildImpl(childEdge, dependencies, childImplTypeName)
+                            }
+                    ScopeImplFactory(
+                            env,
+                            graph,
+                            scope,
+                            getImplTypeName(scope),
+                            getDependencies(scope),
+                            childEdges).create()
+                }
+    }
+
+    private fun getDependencies(scope: Scope): Dependencies {
+        return dependencies.computeIfAbsent(scope) {
+            val implTypeName = getImplTypeName(scope)
+            Dependencies.create(graph, scope, implTypeName)
+        }
+    }
+
+    private fun getImplTypeName(scope: Scope): ClassName {
+        return implTypeNames.computeIfAbsent(scope) {
+            val scopeTypeName = scope.clazz.typeName
+            val prefix = scopeTypeName.simpleNames().joinToString("")
+            ClassName.get(scopeTypeName.packageName(), "${prefix}Impl")
+        }
+    }
+
+    companion object {
+
+        fun generate(env: ProcessingEnvironment, graph: ResolvedGraph): List<GeneratedClass> {
+            return CodeGenerator(env, graph).getScopeImpls()
+        }
+    }
+}

--- a/compiler/src/main/kotlin/motif/compiler/Processor.kt
+++ b/compiler/src/main/kotlin/motif/compiler/Processor.kt
@@ -62,11 +62,10 @@ class Processor : BasicAnnotationProcessor() {
                 return emptySet()
             }
 
-            val scopeImpls = ScopeImpl.create(processingEnv, graph)
+            val generatedClasses = CodeGenerator.generate(processingEnv, graph)
 
-            scopeImpls.forEach { scopeImpl ->
-                val spec = scopeImpl.spec ?: return@forEach
-                JavaFile.builder(scopeImpl.packageName, spec).build().writeTo(processingEnv.filer)
+            generatedClasses.forEach { generatedClass ->
+                JavaFile.builder(generatedClass.packageName, generatedClass.spec).build().writeTo(processingEnv.filer)
             }
 
             return emptySet()

--- a/core/src/main/kotlin/motif/core/ResolvedGraph.kt
+++ b/core/src/main/kotlin/motif/core/ResolvedGraph.kt
@@ -29,6 +29,8 @@ interface ResolvedGraph {
 
     val errors: List<MotifError>
 
+    fun getScope(scopeClass: IrClass): Scope?
+
     fun getChildEdges(scope: Scope): Iterable<ScopeEdge>
 
     fun getChildUnsatisfied(scopeEdge: ScopeEdge): Iterable<Sink>
@@ -110,6 +112,7 @@ private class ErrorGraph(error: MotifError) : ResolvedGraph {
     override val roots = emptyList<Scope>()
     override val scopes = emptyList<Scope>()
     override val errors = listOf(error)
+    override fun getScope(scopeClass: IrClass) = null
     override fun getChildEdges(scope: Scope) = emptyList<ScopeEdge>()
     override fun getChildUnsatisfied(scopeEdge: ScopeEdge) = emptyList<Sink>()
     override fun getUnsatisfied(scope: Scope) = emptyList<Sink>()
@@ -127,6 +130,8 @@ private class ValidResolvedGraph(
     override val scopes = scopeGraph.scopes
 
     override val errors = graphState.errors
+
+    override fun getScope(scopeClass: IrClass) = scopeGraph.getScope(scopeClass)
 
     override fun getChildEdges(scope: Scope) = scopeGraph.getChildEdges(scope)
 

--- a/core/src/main/kotlin/motif/core/ScopeGraph.kt
+++ b/core/src/main/kotlin/motif/core/ScopeGraph.kt
@@ -15,6 +15,7 @@
  */
 package motif.core
 
+import motif.ast.IrClass
 import motif.ast.IrType
 import motif.models.ChildMethod
 import motif.models.Scope
@@ -42,9 +43,13 @@ internal class ScopeGraph private constructor(val scopes: List<Scope>) {
         return childEdges[scope] ?: throw NullPointerException("Scope not found: ${scope.qualifiedName}")
     }
 
+    fun getScope(scopeClass: IrClass): Scope? {
+        return scopeMap[scopeClass.type]
+    }
+
     private fun createChildren(scope: Scope): List<ScopeEdge> {
         return scope.childMethods.map { method ->
-            val childScope = scopeMap[method.childScopeClass.type]
+            val childScope = getScope(method.childScopeClass)
                     ?: throw IllegalStateException("Scope not found: ${scope.qualifiedName}")
             ScopeEdge(scope, childScope, method)
         }


### PR DESCRIPTION
Processor consumes `GeneratedClass` objects instead of `ScopeImpl` directly. This will allow us to generate classes other than just `ScopeImpl`s.