### PR TITLE
Adding javadoc for Dependencies classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3
+
+* Add Javadocs mentioning original consumers of generated Dependencies methods
+
 # 0.1.2
 
 * Enable Daggerless code generation with `-Anodagger=true`

--- a/ast/src/main/kotlin/motif/ast/IrMethod.kt
+++ b/ast/src/main/kotlin/motif/ast/IrMethod.kt
@@ -19,6 +19,7 @@ interface IrMethod : IrAnnotated, IrHasModifiers {
     val parameters: List<IrParameter>
     val returnType: IrType
     val name: String
+    val isConstructor: Boolean
 
     fun hasParameters(): Boolean {
         return parameters.isNotEmpty()

--- a/compiler/ast/src/main/kotlin/motif/ast/compiler/CompilerMethod.kt
+++ b/compiler/ast/src/main/kotlin/motif/ast/compiler/CompilerMethod.kt
@@ -20,6 +20,7 @@ import motif.ast.IrMethod
 import motif.ast.IrModifier
 import motif.ast.IrType
 import javax.annotation.processing.ProcessingEnvironment
+import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.type.DeclaredType
 import javax.lang.model.type.ExecutableType
@@ -31,6 +32,8 @@ class CompilerMethod(
         val element: ExecutableElement) : IrMethod, IrUtil {
 
     override val name: String = element.simpleName.toString()
+
+    override val isConstructor: Boolean = element.kind == ElementKind.CONSTRUCTOR
 
     override val annotations: List<IrAnnotation> by lazy {
         element.irAnnotations()

--- a/intellij/ast/src/main/kotlin/motif/ast/intellij/IntelliJMethod.kt
+++ b/intellij/ast/src/main/kotlin/motif/ast/intellij/IntelliJMethod.kt
@@ -19,7 +19,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiSubstitutor
 import motif.ast.*
-import kotlin.collections.map
 
 class IntelliJMethod(
         private val project: Project,
@@ -33,6 +32,8 @@ class IntelliJMethod(
     override val returnType: IrType by lazy { IntelliJType(project, substitutor.substitute(psiMethod.returnType!!)) }
 
     override val name: String by lazy { psiMethod.name }
+
+    override val isConstructor: Boolean by lazy { psiMethod.isConstructor }
 
     override val annotations: List<IrAnnotation> by lazy { psiMethod.modifierList.irAnnotations(project) }
 


### PR DESCRIPTION
**Description**: This is a draft implementation of what is suggested on issue #33. It adds Javadoc comments for scope dependencies, mostly for traceability.

I had to add a little bit of hack to make constructors be formatted properly for Javadoc (checking if method name == `<init>`), there might be a way to improve this that I'm not seeing.

Also had to use fully qualified type names for all constructor params so Intellij would index it properly (e.g cmd+click-_able_)

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: #33

Changes on Dependencies.kt are be covered by current unit tests, but we could add new tests based on output matching (like the error tests). What do you think?

Screenshot of output (taken from slightly modified sample app):

<img width="1674" alt="Screen Shot 2019-08-22 at 10 52 24" src="https://user-images.githubusercontent.com/1852609/63520347-f4bd5f00-c4ca-11e9-8c5b-87e830c2923d.png">
