### PR TITLE
Use `motif.mode` option to control code generation modes.

### DIFF
--- a/compiler/src/main/kotlin/motif/compiler/codegenv2/ScopeImplFactory.kt
+++ b/compiler/src/main/kotlin/motif/compiler/codegenv2/ScopeImplFactory.kt
@@ -39,7 +39,7 @@ class ScopeImplFactory private constructor(
     private val dependencyMethods = mutableMapOf<Scope, List<DependencyMethodData>>()
 
     private fun create(): List<ScopeImpl> = graph.scopes
-            .filter { scope -> env.elementUtils.getTypeElement(scope.implClassName.toString()) == null }
+            .filter { scope -> env.elementUtils.getTypeElement(scope.implClassName.j.toString()) == null }
             .map { scope ->  Factory(scope).create() }
 
     private inner class Factory(private val scope: Scope) {

--- a/compiler/src/test/java/com/google/testing/compile/MotifTestCompiler.java
+++ b/compiler/src/test/java/com/google/testing/compile/MotifTestCompiler.java
@@ -61,7 +61,7 @@ public class MotifTestCompiler {
             optionsBuilder.add("-d", outDir.getAbsolutePath());
         }
         if (noDagger) {
-            optionsBuilder.add("-Anodagger=true");
+            optionsBuilder.add("-Amotif.mode=java");
         }
 
         JavaCompiler.CompilationTask task = compiler.getTask(


### PR DESCRIPTION
`motif.mode=dagger` generates Dagger-based implementation
`motif.mode=java` generates the pure Java implementation

The default has also been updated to use the pure Java implementation.