### PR TITLE
Throw better exception when generating names for ErrorTypes.

### DIFF
--- a/compiler/src/main/kotlin/motif/compiler/Names.kt
+++ b/compiler/src/main/kotlin/motif/compiler/Names.kt
@@ -120,7 +120,7 @@ private object NameVisitor : SimpleTypeVisitor8<String, Void>() {
     }
 
     override fun visitError(t: ErrorType, p: Void?): String {
-        return visitDeclared(t, p)
+        throw IllegalStateException("Could not generate name for ErrorType: $t. Check your code for missing imports or typos.")
     }
 
     override fun visitArray(t: ArrayType, p: Void?): String {

--- a/compiler/src/test/java/motif/compiler/NamesTest.java
+++ b/compiler/src/test/java/motif/compiler/NamesTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.testing.compile.Compiler.javac;
 
 public class NamesTest {
@@ -93,6 +94,26 @@ public class NamesTest {
     public void customQualifier() {
         String name = getSafeName("@Foo String");
         assertThat(name).isEqualTo("fooString");
+    }
+
+    @Test
+    public void errorType() {
+        try {
+            getSafeName("DoesNotExist");
+            assertWithMessage("Expected Exception to be thrown.");
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("DoesNotExist");
+        }
+    }
+
+    @Test
+    public void errorType_typeArgument() {
+        try {
+            getSafeName("java.util.HashMap<DoesNotExist, Integer>");
+            assertWithMessage("Expected Exception to be thrown.");
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("DoesNotExist");
+        }
     }
 
     private static String getSafeName(String classString) {


### PR DESCRIPTION
**Before**
```
javax.lang.model.element.UnknownElementException: Unknown element:    
```

**After**
```
java.lang.IllegalStateException: Could not generate name for ErrorType: DoesNotExist. Check your code for missing imports or typos.
```