### PR TITLE
Fix concurrent modification exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.2.2-SNAPSHOT
 
+* Do not use computeIfAbsent in ScopeFactory in order to avoid ConcurrentModificationException in the IntelliJ plugin
+
 # 0.2.1
 
 * Improve error message when generate name for ErrorTypes

--- a/models/src/main/kotlin/motif/models/Scope.kt
+++ b/models/src/main/kotlin/motif/models/Scope.kt
@@ -68,12 +68,12 @@ private class ScopeFactory(
         if (visited.contains(scopeType)) return
         visited.add(scopeType)
 
-        scopeMap.computeIfAbsent(scopeType) {
+        if (!scopeMap.containsKey(scopeType)) {
             val scope = Scope(scopeClass)
             scope.childMethods.forEach { childMethod ->
                 visit(childMethod.childScopeClass)
             }
-            scope
+            scopeMap[scopeType] = scope
         }
     }
 }


### PR DESCRIPTION
Do not use computeIfAbsent in ScopeFactory in order to avoid ConcurrentModificationException in the IntelliJ plugin