### PR TITLE
Allow graph processing to proceed even when a ParsingError is encountered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.2.2-SNAPSHOT
 
 * Do not use computeIfAbsent in ScopeFactory in order to avoid ConcurrentModificationException in the IntelliJ plugin
+* Allow graph processing to continue even when a ParsingError is encountered. A malformed Scope will simply not be included in the ResolvedGraph.
 
 # 0.2.1
 

--- a/compiler/src/main/kotlin/motif/compiler/ScopeImplFactory.kt
+++ b/compiler/src/main/kotlin/motif/compiler/ScopeImplFactory.kt
@@ -43,7 +43,7 @@ class ScopeImplFactory private constructor(
 
     private inner class Factory(private val scope: Scope) {
 
-        private val methodNameScope = NameScope(blacklist = scope.scopeMethods.map { it.method.name })
+        private val methodNameScope = NameScope(blacklist = scope.clazz.methods.map { it.name })
         private val fieldNameScope = NameScope(blacklist = listOf(OBJECTS_FIELD_NAME, DEPENDENCIES_FIELD_NAME))
 
         private val providerMethodNames = mutableMapOf<Type, String>()

--- a/core/src/main/kotlin/motif/core/ResolvedGraph.kt
+++ b/core/src/main/kotlin/motif/core/ResolvedGraph.kt
@@ -50,11 +50,7 @@ interface ResolvedGraph {
     companion object {
 
         fun create(initialScopeClasses: List<IrClass>): ResolvedGraph {
-            val scopes = try {
-                Scope.fromClasses(initialScopeClasses)
-            } catch (e: ParsingError) {
-                return ErrorGraph(e)
-            }
+            val scopes = Scope.fromClasses(initialScopeClasses)
             val scopeGraph = ScopeGraph.create(scopes)
             scopeGraph.scopeCycleError?.let { return ErrorGraph(it) }
             return ResolvedGraphFactory(scopeGraph).create()
@@ -141,7 +137,7 @@ private class ValidResolvedGraph(
 
     override val scopes = scopeGraph.scopes
 
-    override val errors = graphState.errors
+    override val errors = scopeGraph.parsingErrors + graphState.errors
 
     override fun getScope(scopeClass: IrClass) = scopeGraph.getScope(scopeClass)
 

--- a/core/src/main/kotlin/motif/core/ScopeGraph.kt
+++ b/core/src/main/kotlin/motif/core/ScopeGraph.kt
@@ -18,6 +18,8 @@ package motif.core
 import motif.ast.IrClass
 import motif.ast.IrType
 import motif.models.ChildMethod
+import motif.models.ErrorScope
+import motif.models.ParsingError
 import motif.models.Scope
 
 class ScopeEdge(val parent: Scope, val child: Scope, val method: ChildMethod)
@@ -38,6 +40,8 @@ internal class ScopeGraph private constructor(val scopes: List<Scope>) {
     val roots: List<Scope> = parentEdges.filter { it.value.isEmpty() }.map { it.key }
 
     val scopeCycleError: ScopeCycleError? = calculateCycle()
+
+    val parsingErrors: List<ParsingError> = scopes.filterIsInstance<ErrorScope>().map { it.parsingError }
 
     fun getChildEdges(scope: Scope): List<ScopeEdge> {
         return childEdges[scope] ?: throw NullPointerException("Scope not found: ${scope.qualifiedName}")


### PR DESCRIPTION
Allow graph processing to proceed even when a ParsingError is encountered. When we encounter a malformed Scope, it is marked as an ErrorScope. Children of ErrorScopes are treated as roots.