### PR TITLE
Handle implicit Kotlin nullability annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Do not use computeIfAbsent in ScopeFactory in order to avoid ConcurrentModificationException in the IntelliJ plugin
 * Allow graph processing to continue even when a ParsingError is encountered. A malformed Scope will simply not be included in the ResolvedGraph.
+* Handle implicit Kotlin Nullability annotations.
 
 # 0.2.1
 

--- a/ast/src/main/kotlin/motif/ast/IrAnnotated.kt
+++ b/ast/src/main/kotlin/motif/ast/IrAnnotated.kt
@@ -26,6 +26,6 @@ interface IrAnnotated {
     }
 
     fun isNullable(): Boolean {
-        return annotations.any { it.type.simpleName == "Nullable" }
+        return annotations.any { it.className.endsWith("Nullable") }
     }
 }

--- a/ast/src/main/kotlin/motif/ast/IrAnnotation.kt
+++ b/ast/src/main/kotlin/motif/ast/IrAnnotation.kt
@@ -19,7 +19,9 @@ import kotlin.reflect.KClass
 
 interface IrAnnotation : IrEquivalence {
 
-    val type: IrType
+    val className: String
+
+    val type: IrType?
 
     val members: List<IrMethod>
 

--- a/compiler/ast/src/main/kotlin/motif/ast/compiler/CompilerAnnotation.kt
+++ b/compiler/ast/src/main/kotlin/motif/ast/compiler/CompilerAnnotation.kt
@@ -30,11 +30,12 @@ class CompilerAnnotation(
         env: ProcessingEnvironment,
         val mirror: AnnotationMirror) : IrAnnotation {
 
-    private val key: Equivalence.Wrapper<AnnotationMirror> = AnnotationMirrors.equivalence().wrap(mirror)
-    private val className: String by lazy {
+    override val className: String by lazy {
         val typeElement = mirror.annotationType.asElement() as TypeElement
         typeElement.qualifiedName.toString()
     }
+
+    private val key: Equivalence.Wrapper<AnnotationMirror> = AnnotationMirrors.equivalence().wrap(mirror)
     private val pretty: String by lazy { mirror.toString() }
 
     override val type: IrType = CompilerType(env, mirror.annotationType)

--- a/errormessage/src/main/kotlin/motif/errormessage/InvalidQualifierHandler.kt
+++ b/errormessage/src/main/kotlin/motif/errormessage/InvalidQualifierHandler.kt
@@ -25,7 +25,7 @@ internal class InvalidQualifierHandler(private val error: InvalidQualifier) : Er
         appendln("""
             Qualifier must define either no members or a single value member of type String:
 
-              ${error.annotationType.qualifiedName}
+              ${error.annotation.className}
         """.trimIndent())
     }
 }

--- a/intellij/ast/build.gradle
+++ b/intellij/ast/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 intellij {
-    version 'IC-2018.3'
-    plugins = []
+    version 'IC-2019.2'
+    plugins = [ 'java', 'Kotlin' ]
     pluginName 'MyPlugin'
     updateSinceUntilBuild = false
 }
@@ -20,4 +20,16 @@ dependencies {
     testCompile deps.test.junit
     testCompile deps.test.assertj
     testCompile project(':intellij:testing')
+}
+
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/intellij/ast/src/main/kotlin/motif/ast/intellij/IntelliJAnnotation.kt
+++ b/intellij/ast/src/main/kotlin/motif/ast/intellij/IntelliJAnnotation.kt
@@ -34,17 +34,17 @@ class IntelliJAnnotation(
         getStringConstantValue(project, psiAnnotation, "value")
     }
 
-    private val qualifiedName: String by lazy {
+    override val className: String by lazy {
         psiAnnotation.qualifiedName!!
     }
 
     private val key: Key by lazy {
-        Key(qualifiedName, stringValue)
+        Key(className, stringValue)
     }
 
-    override val type: IrType by lazy {
+    override val type: IrType? by lazy {
         val nameReferenceElement = psiAnnotation.nameReferenceElement
-        val annotationClass: PsiClass = nameReferenceElement?.resolve() as? PsiClass ?: throw IllegalStateException("$nameReferenceElement")
+        val annotationClass: PsiClass = nameReferenceElement?.resolve() as? PsiClass ?: return@lazy null
         val psiClassType: PsiClassType = PsiElementFactory.SERVICE.getInstance(project).createType(annotationClass)
         IntelliJType(project, psiClassType)
     }
@@ -100,5 +100,5 @@ class IntelliJAnnotation(
         }
     }
 
-    private data class Key(val qualifiedName: String, val value: String?)
+    private data class Key(val className: String, val value: String?)
 }

--- a/intellij/ast/src/test/kotlin/motif/ast/intellij/IntelliJAnnotationTest.kt
+++ b/intellij/ast/src/test/kotlin/motif/ast/intellij/IntelliJAnnotationTest.kt
@@ -235,6 +235,17 @@ class IntelliJAnnotationTest : LightCodeInsightFixtureTestCase() {
         assertThat(fooAnnotation).isNotEqualTo(barAnnotation)
     }
 
+    fun testClassName() {
+        val fooAnnotation = getClassAnnotation("""
+            package test;
+
+            @javax.inject.Named("a")
+            class Foo {}
+        """.trimIndent())
+
+        assertThat(fooAnnotation.className).isEqualTo("javax.inject.Named")
+    }
+
     private fun createAnnotationClass(@Language("JAVA") classText: String): IntelliJClass {
         val psiClass = myFixture.addClass(classText)
         return IntelliJClass(project, psiElementFactory.createType(psiClass))

--- a/intellij/ast/src/test/kotlin/motif/ast/intellij/IntelliJKotlinTest.kt
+++ b/intellij/ast/src/test/kotlin/motif/ast/intellij/IntelliJKotlinTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.ast.intellij
+
+import com.intellij.pom.java.LanguageLevel
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElementFactory
+import com.intellij.testFramework.LightProjectDescriptor
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
+import motif.intellij.testing.InternalJdk
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.nj2k.postProcessing.type
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.toUElement
+import org.jetbrains.uast.toUElementOfType
+
+class IntelliJKotlinTest : LightCodeInsightFixtureTestCase() {
+
+    lateinit var psiElementFactory: PsiElementFactory
+
+    override fun setUp() {
+        super.setUp()
+
+        psiElementFactory = PsiElementFactory.SERVICE.getInstance(project)
+    }
+
+    override fun getProjectDescriptor(): LightProjectDescriptor {
+        return object : ProjectDescriptor(LanguageLevel.HIGHEST) {
+            override fun getSdk() = InternalJdk.instance
+        }
+    }
+
+    override fun getTestDataPath(): String {
+        return "testData"
+    }
+
+    fun testImplicitNullabilityAnnotationType() {
+        val fooPsiFile = myFixture.addFileToProject("Foo.kt", """
+            open class Foo(val s: String) {
+                
+                internal fun a() {}
+            }
+        """.trimIndent()) as KtFile
+
+        val fooPsiClass = fooPsiFile.declarations[0].toUElementOfType<UClass>()!!.javaPsi
+        val psiAnnotation = fooPsiClass.constructors[0].parameterList.parameters[0].annotations[0]
+        val annotation = IntelliJAnnotation(project, psiAnnotation)
+
+        assertThat(annotation.type).isNull()
+        assertThat(annotation.className).isEqualTo("org.jetbrains.annotations.NotNull")
+    }
+}

--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 intellij {
-    version 'IC-2018.3'
-    plugins = []
+    version 'IC-2019.2'
+    plugins = [ 'java', 'Kotlin' ]
     pluginName 'MyPlugin'
     updateSinceUntilBuild = false
 }

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -16,6 +16,7 @@
     </change-notes>
 
     <depends>com.intellij.modules.java</depends>
+    <depends>org.jetbrains.kotlin</depends>
     <depends>com.intellij.modules.lang</depends>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/intellij/src/test/kotlin/motif/intellij/TestHarness.kt
+++ b/intellij/src/test/kotlin/motif/intellij/TestHarness.kt
@@ -16,13 +16,11 @@
 package motif.intellij
 
 import com.google.common.truth.Truth.assertThat
-import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl
 import com.intellij.pom.java.LanguageLevel
 import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.Parameterized
 import com.intellij.testFramework.PsiTestUtil
-import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import motif.Scope
 import motif.core.ResolvedGraph
 import motif.errormessage.ErrorMessage
@@ -40,7 +38,7 @@ import javax.inject.Inject
 import kotlin.reflect.KClass
 
 @RunWith(Parameterized::class)
-class TestHarness : LightCodeInsightFixtureTestCase() {
+class TestHarness : LightJavaCodeInsightFixtureTestCase() {
 
     @get:Rule val rule = IntelliJRule()
 
@@ -71,7 +69,7 @@ class TestHarness : LightCodeInsightFixtureTestCase() {
         val path = clazz.java.protectionDomain.codeSource.location.path
         val file = File(path)
         val libName = file.name
-        PsiTestUtil.addLibrary(myFixture.projectDisposable, myModule, libName, file.parent, libName)
+        PsiTestUtil.addLibrary(myFixture.projectDisposable, module, libName, file.parent, libName)
     }
 
     @Test

--- a/models/src/main/kotlin/motif/models/ParsingError.kt
+++ b/models/src/main/kotlin/motif/models/ParsingError.kt
@@ -36,5 +36,5 @@ class NotAssignableBindsMethod(val objects: Objects, val method: IrMethod, val r
 class VoidDependenciesMethod(val scope: Scope, val dependenciesClass: IrClass, val method: IrMethod) : ParsingError()
 class DependencyMethodWithParameters(val scope: Scope, val dependenciesClass: IrClass, val method: IrMethod) : ParsingError()
 class NullableSpreadMethod(val objects: Objects, val factoryMethod: IrMethod, val spreadClass: IrClass, val spreadMethod: IrMethod) : ParsingError()
-class InvalidQualifier(val annotated: IrAnnotated, val annotationType: IrType) : ParsingError()
+class InvalidQualifier(val annotated: IrAnnotated, val annotation: IrAnnotation) : ParsingError()
 class DuplicatedChildParameterSource(val scope: Scope, val childScopeMethod: ChildMethod, val duplicatedParameters: List<ChildMethod.Parameter>) : ParsingError()

--- a/models/src/main/kotlin/motif/models/Spread.kt
+++ b/models/src/main/kotlin/motif/models/Spread.kt
@@ -29,7 +29,7 @@ class Spread(val clazz: IrClass, val factoryMethod: FactoryMethod) {
     val methods: List<Method> = clazz.methods
             .filter { method -> isSpreadMethod(method) }
             .onEach { method ->
-                if (method.annotations.any { it.type.simpleName == "Nullable" }) {
+                if (method.isNullable()) {
                     throw NullableSpreadMethod(factoryMethod.objects, factoryMethod.method, clazz, method)
                 }
             }

--- a/models/src/main/kotlin/motif/models/Type.kt
+++ b/models/src/main/kotlin/motif/models/Type.kt
@@ -55,19 +55,19 @@ data class Type(val type: IrType, val qualifier: IrAnnotation?) : Comparable<Typ
 
         private fun IrAnnotated.getQualifier(): IrAnnotation? {
             val qualifier = annotations.find { annotation ->
-                val annotationClass: IrClass = annotation.type.resolveClass() ?: return@find false
+                val annotationClass: IrClass = annotation.type?.resolveClass() ?: return@find false
                 annotationClass.hasAnnotation(Qualifier::class)
             } ?: return null
 
             val members = qualifier.members
             if (members.size > 1) {
-                throw InvalidQualifier(this, qualifier.type)
+                throw InvalidQualifier(this, qualifier)
             }
 
             if (members.size == 1) {
                 val member = members[0]
                 if (member.name != "value" || member.returnType.qualifiedName != "java.lang.String") {
-                    throw InvalidQualifier(this, qualifier.type)
+                    throw InvalidQualifier(this, qualifier)
                 }
             }
 


### PR DESCRIPTION
The IntelliJ plugin was failing due to unexpected behavior when processing implicit nullability annotations added to Kotlin parameters. This change allows us to handle annotations even if they don't exist on the classpath.