### PR TITLE
[IntelliJ Plugin] Add support for Search Usage feature

### DIFF
--- a/intellij/src/main/kotlin/motif/intellij/ScopeHierarchyUtils.kt
+++ b/intellij/src/main/kotlin/motif/intellij/ScopeHierarchyUtils.kt
@@ -20,6 +20,8 @@ import com.intellij.psi.*
 import com.intellij.psi.impl.source.PsiClassReferenceType
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
+import motif.ast.IrType
+import motif.ast.intellij.IntelliJType
 import motif.core.ResolvedGraph
 import motif.core.ScopeEdge
 import motif.models.Scope
@@ -51,6 +53,30 @@ class ScopeHierarchyUtils {
                 }
             }
             return false
+        }
+
+        /*
+         * Returns the number of usage for the given class.
+         */
+        fun getUsageCount(project: Project, graph: ResolvedGraph, clazz: PsiClass, includeSources: Boolean = true, includeSinks: Boolean = true): Int {
+            var count = 0
+            val elementType: PsiType = PsiElementFactory.SERVICE.getInstance(project).createType(clazz)
+            val type: IrType = IntelliJType(project, elementType)
+            if (includeSources) {
+                graph.getSources(type).forEach { _ -> count++ }
+            }
+            if (includeSinks) {
+                graph.getSinks(type).forEach { _ -> count++ }
+            }
+            return count
+        }
+
+        fun getUsageString(count: Int): String {
+            return when (count) {
+                0 -> "No usage"
+                1 -> "1 usage"
+                else -> "$count usages"
+            }
         }
 
         /*

--- a/intellij/src/main/kotlin/motif/intellij/actions/MotifUsageAction.kt
+++ b/intellij/src/main/kotlin/motif/intellij/actions/MotifUsageAction.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.intellij.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import motif.core.ResolvedGraph
+import motif.intellij.MotifProjectComponent
+import motif.intellij.MotifProjectComponent.Companion.TOOL_WINDOW_ID
+import motif.intellij.ScopeHierarchyUtils.Companion.getUsageCount
+
+/*
+ * {@AnAction} used to trigger navigation to a particular scope in the scope hierarchy window.
+ */
+class MotifUsageAction : AnAction(), MotifProjectComponent.Listener {
+
+    private var graph: ResolvedGraph? = null
+
+    override fun onGraphUpdated(graph: ResolvedGraph) {
+        this.graph = graph
+    }
+
+    override fun actionPerformed(event: AnActionEvent) {
+        val project = event.project ?: return
+        val element = event.getPsiElement() ?: return
+
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+
+        val toolWindow: ToolWindow = ToolWindowManager.getInstance(project).getToolWindow(TOOL_WINDOW_ID)
+        toolWindow.activate {
+            MotifProjectComponent.getInstance(project).onSelectedClass(element)
+        }
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project ?: return
+        val graph = this.graph ?: return
+        val element: PsiElement? = e.getPsiElement()
+        e.presentation.isEnabled = element is PsiClass && getUsageCount(project, graph, element) > 0
+    }
+
+    private fun AnActionEvent.getPsiElement(): PsiElement? {
+        return getData(CommonDataKeys.PSI_ELEMENT)
+    }
+}

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/UsageHierarchyBrowser.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/UsageHierarchyBrowser.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.intellij.hierarchy
+
+import com.intellij.ide.hierarchy.HierarchyBrowserBaseEx
+import com.intellij.ide.hierarchy.HierarchyNodeDescriptor
+import com.intellij.ide.hierarchy.HierarchyTreeStructure
+import com.intellij.ide.hierarchy.JavaHierarchyUtil
+import com.intellij.ide.util.treeView.NodeDescriptor
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.DataKey
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.presentation.java.ClassPresentationUtil
+import motif.core.ResolvedGraph
+import motif.intellij.MotifProjectComponent
+import motif.intellij.hierarchy.ScopeHierarchyBrowser.Companion.LABEL_GO_NEXT_SCOPE
+import motif.intellij.hierarchy.ScopeHierarchyBrowser.Companion.LABEL_GO_PREVIOUS_SCOPE
+import motif.intellij.hierarchy.descriptor.ScopeHierarchyUsageSectionDescriptor
+import java.text.MessageFormat
+import java.util.*
+import javax.swing.JPanel
+import javax.swing.JTree
+
+/*
+ * UI component used to render usage.
+ */
+class UsageHierarchyBrowser(
+        val project: Project,
+        initialGraph: ResolvedGraph,
+        private val rootElement: PsiElement)
+    : HierarchyBrowserBaseEx(project, rootElement), MotifProjectComponent.Listener {
+
+    private var graph: ResolvedGraph = initialGraph
+
+    companion object {
+        const val USAGE_HIERARCHY_TYPE: String = "Usage"
+        private val DATA_KEY = DataKey.create<UsageHierarchyBrowser>(UsageHierarchyBrowser::class.java.name)
+    }
+
+    fun setSelectedClass(element: PsiClass) {
+        hierarchyBase = element
+        super.doRefresh(true)
+    }
+
+    override fun isApplicableElement(element: PsiElement): Boolean {
+        return element is PsiClass
+    }
+
+    override fun getActionPlace(): String {
+        return ActionPlaces.METHOD_HIERARCHY_VIEW_TOOLBAR
+    }
+
+    override fun prependActions(actionGroup: DefaultActionGroup) {
+    }
+
+    override fun getComparator(): Comparator<NodeDescriptor<Any>>? {
+        return JavaHierarchyUtil.getComparator(myProject)
+    }
+
+    override fun getElementFromDescriptor(descriptor: HierarchyNodeDescriptor): PsiElement? {
+        return descriptor.psiElement
+    }
+
+    override fun getPrevOccurenceActionNameImpl(): String {
+        return LABEL_GO_PREVIOUS_SCOPE
+    }
+
+    override fun getNextOccurenceActionNameImpl(): String {
+        return LABEL_GO_NEXT_SCOPE
+    }
+
+    override fun createLegendPanel(): JPanel? {
+        return null
+    }
+
+    override fun createTrees(trees: MutableMap<String, JTree>) {
+        trees[USAGE_HIERARCHY_TYPE] = createTree(true)
+    }
+
+    override fun getContentDisplayName(typeName: String, element: PsiElement): String? {
+        return MessageFormat.format(typeName, ClassPresentationUtil.getNameForClass(element as PsiClass, false))
+    }
+
+    override fun createHierarchyTreeStructure(typeName: String, psiElement: PsiElement): HierarchyTreeStructure? {
+        if (psiElement is PsiClass) {
+            val descriptor: HierarchyNodeDescriptor = ScopeHierarchyUsageSectionDescriptor(project, graph, null, psiElement)
+            return ScopeHierarchyTreeStructure(project, graph, descriptor)
+        }
+        return null
+    }
+
+    override fun getBrowserDataKey(): String {
+        return DATA_KEY.name
+    }
+
+    override fun onGraphUpdated(graph: ResolvedGraph) {
+        this.graph = graph
+        super.doRefresh(true)
+    }
+}

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyUsageSectionDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyUsageSectionDescriptor.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.intellij.hierarchy.descriptor
+
+import com.intellij.ide.hierarchy.HierarchyNodeDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ui.util.CompositeAppearance
+import com.intellij.psi.PsiClass
+import motif.core.ResolvedGraph
+import motif.intellij.ScopeHierarchyUtils.Companion.getUsageCount
+import motif.intellij.ScopeHierarchyUtils.Companion.getUsageString
+
+open class ScopeHierarchyUsageSectionDescriptor(
+        private val nonNullproject: Project,
+        graph: ResolvedGraph,
+        parentDescriptor: HierarchyNodeDescriptor?,
+        val clazz: PsiClass)
+    : ScopeHierarchyNodeDescriptor(nonNullproject, graph, parentDescriptor, clazz, false) {
+
+    override fun updateText(text: CompositeAppearance) {
+        val count: Int = getUsageCount(nonNullproject, graph, clazz)
+        text.ending.addText("Found usages")
+        text.ending.addText(" " + getUsageString(count), getPackageNameAttributes())
+    }
+}

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyUsageSinksSectionDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyUsageSinksSectionDescriptor.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.intellij.hierarchy.descriptor
+
+import com.intellij.ide.hierarchy.HierarchyNodeDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ui.util.CompositeAppearance
+import com.intellij.psi.PsiClass
+import motif.core.ResolvedGraph
+import motif.intellij.ScopeHierarchyUtils.Companion.getUsageCount
+import motif.intellij.ScopeHierarchyUtils.Companion.getUsageString
+
+open class ScopeHierarchyUsageSinksSectionDescriptor(
+        private val nonNullProject: Project,
+        graph: ResolvedGraph,
+        parentDescriptor: HierarchyNodeDescriptor?,
+        val clazz: PsiClass)
+    : ScopeHierarchyNodeDescriptor(nonNullProject, graph, parentDescriptor, clazz, false) {
+
+    override fun updateText(text: CompositeAppearance) {
+        val count: Int = getUsageCount(nonNullProject, graph, clazz, includeSources = false, includeSinks = true)
+        text.ending.addText("Consumes")
+        text.ending.addText(" " +  getUsageString(count), getPackageNameAttributes())
+    }
+}

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyUsageSourcesSectionDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyUsageSourcesSectionDescriptor.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.intellij.hierarchy.descriptor
+
+import com.intellij.ide.hierarchy.HierarchyNodeDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ui.util.CompositeAppearance
+import com.intellij.psi.PsiClass
+import motif.core.ResolvedGraph
+import motif.intellij.ScopeHierarchyUtils.Companion.getUsageCount
+import motif.intellij.ScopeHierarchyUtils.Companion.getUsageString
+
+open class ScopeHierarchyUsageSourcesSectionDescriptor(
+        private val nonNullProject: Project,
+        graph: ResolvedGraph,
+        parentDescriptor: HierarchyNodeDescriptor?,
+        val clazz: PsiClass)
+    : ScopeHierarchyNodeDescriptor(nonNullProject, graph, parentDescriptor, clazz, false) {
+
+    override fun updateText(text: CompositeAppearance) {
+        val count: Int = getUsageCount(nonNullProject, graph, clazz, includeSources = true, includeSinks = false)
+        text.ending.addText("Provides")
+        text.ending.addText(" " +  getUsageString(count), getPackageNameAttributes())
+    }
+}

--- a/intellij/src/main/kotlin/motif/intellij/ui/MotifUsagePanel.kt
+++ b/intellij/src/main/kotlin/motif/intellij/ui/MotifUsagePanel.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.intellij.ui
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import motif.core.ResolvedGraph
+import motif.intellij.MotifProjectComponent
+import motif.intellij.ScopeHierarchyUtils
+import motif.intellij.hierarchy.UsageHierarchyBrowser
+import java.awt.BorderLayout
+import javax.swing.JPanel
+
+class MotifUsagePanel(project: Project, graph: ResolvedGraph) : JPanel(), MotifProjectComponent.Listener {
+
+    private val usageBrowser: UsageHierarchyBrowser
+
+    init {
+        val rootElement: PsiElement = ScopeHierarchyUtils.buildRootElement(project)
+
+        // Build UI
+        layout = BorderLayout()
+
+        usageBrowser = UsageHierarchyBrowser(project, graph, rootElement)
+        usageBrowser.changeView(UsageHierarchyBrowser.USAGE_HIERARCHY_TYPE)
+
+        add(usageBrowser)
+    }
+
+    fun setSelectedClass(clazz: PsiClass) {
+        usageBrowser.setSelectedClass(clazz)
+    }
+
+    override fun onGraphUpdated(graph: ResolvedGraph) {
+        usageBrowser.onGraphUpdated(graph)
+    }
+}
+

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -27,19 +27,30 @@
     </project-components>
 
     <actions>
-        <action class="motif.intellij.actions.MotifGraphAction" description="Display Motif graph for this scope" icon="/images/graph.png" id="View scope Motif graph" text="View scope Motif graph">
+        <action class="motif.intellij.actions.MotifGraphAction" description="Display Motif graph for this scope" icon="/images/graph.png" id="motif_graph" text="View Scope Graph">
             <keyboard-shortcut first-keystroke="control shift S" keymap="$default"/>
+        </action>
+        <action class="motif.intellij.actions.MotifUsageAction" description="Display Motif usage for this object" icon="/images/graph.png" id="motif_usage" text="Find Usages">
+            <keyboard-shortcut first-keystroke="control shift U" keymap="$default"/>
         </action>
 
         <group id="MotifEditor" popup="true" text="Motif">
-            <reference ref="View scope Motif graph"/>
+            <reference ref="motif_usage"/>
             <add-to-group anchor="first" group-id="EditorPopupMenu"/>
+        </group>
+        <group id="MotifGraphEditor">
+            <reference ref="motif_graph"/>
+            <add-to-group anchor="first" group-id="MotifEditor"/>
         </group>
 
         <group id="MotifProject" popup="true" text="Motif">
-            <reference ref="View scope Motif graph"/>
+            <reference ref="motif_graph"/>
             <add-to-group anchor="first" group-id="ProjectViewPopupMenu"/>
             <add-to-group anchor="first" group-id="StructureViewPopupMenu"/>
+        </group>
+        <group id="MotifUsageProject">
+            <reference ref="motif_usage"/>
+            <add-to-group anchor="last" group-id="MotifProject"/>
         </group>
     </actions>
 


### PR DESCRIPTION
This diff adds the ability to search for usage of a given class in the motif graph. It opens a separate tab within the IntelliJ plugin main window, with the list of places for an object of the supplied class types are produces and consumed.

<img width="526" alt="Screen Shot 2019-12-02 at 4 48 40 PM" src="https://user-images.githubusercontent.com/52428902/70006952-9d944500-1523-11ea-9c97-c5bbcf7ac32a.png">
