### PR TITLE
Support for navigating to parent scope w/ multiple parents

### DIFF
--- a/intellij/src/main/kotlin/motif/intellij/MotifProjectComponent.kt
+++ b/intellij/src/main/kotlin/motif/intellij/MotifProjectComponent.kt
@@ -62,6 +62,7 @@ class MotifProjectComponent(val project: Project) : ProjectComponent {
     private var scopePanel: MotifScopePanel? = null
     private var errorPanel: MotifErrorPanel? = null
     private var usagePanel: MotifUsagePanel? = null
+    private var scopeContent: Content? = null
     private var usageContent: Content? = null
     private var errorContent: Content? = null
     private var isRefreshing: Boolean = false
@@ -101,6 +102,8 @@ class MotifProjectComponent(val project: Project) : ProjectComponent {
             return
         }
         scopePanel?.setSelectedScope(element)
+        val toolWindow: ToolWindow = ToolWindowManager.getInstance(project).getToolWindow(TOOL_WINDOW_ID) ?: return
+        scopeContent?.let { toolWindow.contentManager.setSelectedContent(it) }
     }
 
     fun onSelectedClass(element: PsiElement) {
@@ -123,9 +126,9 @@ class MotifProjectComponent(val project: Project) : ProjectComponent {
                 toolWindow.title = TOOL_WINDOW_TITLE
 
                 scopePanel = MotifScopePanel(project, graph)
-                val scopesContent: Content = ContentFactory.SERVICE.getInstance().createContent(scopePanel, TAB_NAME_SCOPES, true)
-                scopesContent.isCloseable = false
-                toolWindow.contentManager.addContent(scopesContent)
+                scopeContent = ContentFactory.SERVICE.getInstance().createContent(scopePanel, TAB_NAME_SCOPES, true)
+                scopeContent?.isCloseable = false
+                scopeContent?.let { toolWindow.contentManager.addContent(it) }
 
                 errorPanel = MotifErrorPanel(project, graph)
                 usagePanel = MotifUsagePanel(project, graph)


### PR DESCRIPTION
Display a listbox whenever scope has multiple parents, to let developers pick which parent she wants to navigate to.

<img width="683" alt="Screen Shot 2019-12-03 at 2 05 43 PM" src="https://user-images.githubusercontent.com/52428902/70094059-882c2300-15d6-11ea-9d89-d4a07ddb5c3b.png">
