### PR TITLE
Avoid IDE startup slowdown by not computing graph on plugin startup, add missing icons

### DIFF
--- a/intellij/src/main/kotlin/motif/intellij/GraphFactory.kt
+++ b/intellij/src/main/kotlin/motif/intellij/GraphFactory.kt
@@ -15,9 +15,6 @@
  */
 package motif.intellij
 
-import com.intellij.notification.Notification
-import com.intellij.notification.NotificationType
-import com.intellij.notification.Notifications
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
@@ -33,8 +30,6 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.uast.UClass
 import org.jetbrains.uast.toUElement
-import org.jetbrains.uast.toUElementOfType
-import kotlin.system.measureTimeMillis
 
 class GraphFactory(private val project: Project) {
 
@@ -42,8 +37,8 @@ class GraphFactory(private val project: Project) {
     private val psiElementFactory = PsiElementFactory.SERVICE.getInstance(project)
 
     fun compute(): ResolvedGraph {
-        val scopeClasses = { getScopeClasses() }.runAndLog("Found Scope classes.")
-        return { ResolvedGraph.create(scopeClasses) }.runAndLog("Processed graph.")
+        val scopeClasses: List<IrClass> = getScopeClasses()
+        return ResolvedGraph.create(scopeClasses)
     }
 
     private fun getScopeClasses(): List<IrClass> {
@@ -85,17 +80,5 @@ class GraphFactory(private val project: Project) {
 
     private fun isScopeClass(psiClass: PsiClass): Boolean {
         return psiClass.annotations.find { it.qualifiedName == Scope::class.qualifiedName} != null
-    }
-
-    private fun <T : Any> (() -> T).runAndLog(message: String): T {
-        lateinit var result: T
-        val duration = measureTimeMillis { result = this() }
-        log("$message (${duration}ms)")
-        return result
-    }
-
-    private fun log(message: String) {
-        Notifications.Bus.notify(
-                Notification("Motif", "Motif Graph", message, NotificationType.INFORMATION))
     }
 }

--- a/intellij/src/main/kotlin/motif/intellij/actions/MotifGraphAction.kt
+++ b/intellij/src/main/kotlin/motif/intellij/actions/MotifGraphAction.kt
@@ -23,13 +23,21 @@ import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
+import motif.core.ResolvedGraph
 import motif.intellij.MotifProjectComponent
+import motif.intellij.ScopeHierarchyUtils.Companion.getParentScopes
 import motif.intellij.ScopeHierarchyUtils.Companion.isMotifScopeClass
 
 /*
  * {@AnAction} used to trigger displaying a particular scope ancestors hierarchy.
  */
-class MotifGraphAction : AnAction() {
+class MotifGraphAction : AnAction(), MotifProjectComponent.Listener {
+
+    private var graph: ResolvedGraph? = null
+
+    override fun onGraphUpdated(graph: ResolvedGraph) {
+        this.graph = graph
+    }
 
     override fun actionPerformed(event: AnActionEvent) {
         val project = event.project ?: return
@@ -44,8 +52,10 @@ class MotifGraphAction : AnAction() {
     }
 
     override fun update(e: AnActionEvent) {
+        val project = e.project ?: return
+        val graph = this.graph ?: return
         val element: PsiElement? = e.getPsiElement()
-        e.presentation.isEnabled = element is PsiClass && isMotifScopeClass(element)
+        e.presentation.isEnabled = element is PsiClass && isMotifScopeClass(element) && (getParentScopes(project, graph, element)?.isNotEmpty() == true)
     }
 
     private fun AnActionEvent.getPsiElement(): PsiElement? {

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyRootScopeNodeDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyRootScopeNodeDescriptor.kt
@@ -20,16 +20,29 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ui.util.CompositeAppearance
 import com.intellij.psi.PsiElement
 import motif.core.ResolvedGraph
+import motif.intellij.hierarchy.ScopeHierarchyBrowser
 
-class ScopeHierarchyRootDescriptor(project: Project, graph: ResolvedGraph, element: PsiElement) :
+class ScopeHierarchyRootDescriptor(project: Project, graph: ResolvedGraph, element: PsiElement, private val status: ScopeHierarchyBrowser.Status) :
         ScopeHierarchyNodeDescriptor(project, graph, null, element, true) {
 
     companion object {
         const val LABEL_ROOT_SCOPES: String = "Root Scopes"
+        const val LABEL_CLICK_REFRESH: String = "Click Refresh button to access Motif scope hierarchy."
+        const val LABEL_WAIT: String = "Please wait..."
     }
 
     override fun updateText(text: CompositeAppearance) {
-        val textAttr: TextAttributes = getDefaultTextAttributes(graph.errors.isNotEmpty())
-        text.ending.addText(LABEL_ROOT_SCOPES, textAttr)
+        when (status) {
+            ScopeHierarchyBrowser.Status.UNINITIALIZED -> {
+                text.ending.addText(LABEL_CLICK_REFRESH)
+            }
+            ScopeHierarchyBrowser.Status.INITIALIZING -> {
+                text.ending.addText(LABEL_WAIT)
+            }
+            else -> {
+                val textAttr: TextAttributes = getDefaultTextAttributes(graph.errors.isNotEmpty())
+                text.ending.addText(LABEL_ROOT_SCOPES, textAttr)
+            }
+        }
     }
 }

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -34,7 +34,7 @@
             <keyboard-shortcut first-keystroke="control shift U" keymap="$default"/>
         </action>
 
-        <group id="MotifEditor" popup="true" text="Motif">
+        <group id="MotifEditor" icon="/icons/icon.svg" popup="true" text="Motif">
             <reference ref="motif_usage"/>
             <add-to-group anchor="first" group-id="EditorPopupMenu"/>
         </group>
@@ -43,7 +43,7 @@
             <add-to-group anchor="first" group-id="MotifEditor"/>
         </group>
 
-        <group id="MotifProject" popup="true" text="Motif">
+        <group id="MotifProject" icon="/icons/icon.svg" popup="true" text="Motif">
             <reference ref="motif_graph"/>
             <add-to-group anchor="first" group-id="ProjectViewPopupMenu"/>
             <add-to-group anchor="first" group-id="StructureViewPopupMenu"/>


### PR DESCRIPTION
- Change behavior so that user currently has to explicitly refresh the graph in order to use the plugin.
- Update missing icon in menus
- Remove necessary logging code

Detecting plugin window opening (and compute initial graph automatically) would require refactoring to use [ToolWindowFactory](https://www.jetbrains.org/intellij/sdk/docs/user_interface_components/tool_windows.html) 