### PR TITLE
Create ScopeDescriptor to isolate scope content and delegate its usage

### DIFF
--- a/core/src/main/kotlin/motif/core/ResolvedGraph.kt
+++ b/core/src/main/kotlin/motif/core/ResolvedGraph.kt
@@ -22,19 +22,9 @@ import motif.models.*
 /**
  * Full representation of the Scope and dependency graph.
  */
-interface ResolvedGraph {
-
-    val roots: List<Scope>
-
-    val scopes: List<Scope>
+interface ResolvedGraph : ScopeDescriptor {
 
     val errors: List<MotifError>
-
-    fun getScope(scopeType: IrType): Scope?
-
-    fun getChildEdges(scope: Scope): Iterable<ScopeEdge>
-
-    fun getParentEdges(scope: Scope): Iterable<ScopeEdge>
 
     fun getChildUnsatisfied(scopeEdge: ScopeEdge): Iterable<Sink>
 
@@ -144,21 +134,11 @@ private class ValidResolvedGraph(
         private val scopeGraph: ScopeGraph,
         private val scopeStates: Map<Scope, State>,
         private val childStates: Map<ScopeEdge, State>,
-        private val graphState: State) : ResolvedGraph {
+        private val graphState: State) : ResolvedGraph, ScopeDescriptor by scopeGraph {
 
     private val scopeSinks = mutableMapOf<Scope, Set<Sink>>()
 
-    override val roots = scopeGraph.roots
-
-    override val scopes = scopeGraph.scopes
-
     override val errors = scopeGraph.parsingErrors + graphState.errors
-
-    override fun getScope(scopeType: IrType) = scopeGraph.getScope(scopeType)
-
-    override fun getChildEdges(scope: Scope) = scopeGraph.getChildEdges(scope)
-
-    override fun getParentEdges(scope: Scope) = scopeGraph.getParentEdges(scope)
 
     override fun getChildUnsatisfied(scopeEdge: ScopeEdge) = childStates.getValue(scopeEdge).unsatisfied
 

--- a/core/src/main/kotlin/motif/core/ScopeGraph.kt
+++ b/core/src/main/kotlin/motif/core/ScopeGraph.kt
@@ -15,7 +15,6 @@
  */
 package motif.core
 
-import motif.ast.IrClass
 import motif.ast.IrType
 import motif.models.ChildMethod
 import motif.models.ErrorScope
@@ -25,10 +24,27 @@ import motif.models.Scope
 class ScopeEdge(val parent: Scope, val child: Scope, val method: ChildMethod)
 
 /**
+ * A representation of Scope, what is consist of and what it contains
+ */
+interface ScopeDescriptor {
+
+    val roots: List<Scope>
+
+    val scopes: List<Scope>
+
+    fun getScope(scopeType: IrType): Scope?
+
+    fun getChildEdges(scope: Scope): Iterable<ScopeEdge>
+
+    fun getParentEdges(scope: Scope): Iterable<ScopeEdge>
+
+}
+
+/**
  * Graph of [Scopes][Scope] as defined by [Scope.childMethods]. Throws an [IllegalStateException] if any of a
  * Scope's childEdge Scopes does not exist in the initial list of Scopes.
  */
-internal class ScopeGraph private constructor(val scopes: List<Scope>) {
+internal class ScopeGraph private constructor(override val scopes: List<Scope>) : ScopeDescriptor {
 
     private val scopeMap: Map<IrType, Scope> = scopes.associateBy { it.clazz.type }
     private val childEdges: Map<Scope, List<ScopeEdge>> = scopes.associate { scope -> scope to createChildren(scope) }
@@ -37,21 +53,21 @@ internal class ScopeGraph private constructor(val scopes: List<Scope>) {
         scopes.associateWith { mapping[it] ?: emptyList() }
     }()
 
-    val roots: List<Scope> = parentEdges.filter { it.value.isEmpty() }.map { it.key }
+    override val roots: List<Scope> = parentEdges.filter { it.value.isEmpty() }.map { it.key }
 
     val scopeCycleError: ScopeCycleError? = calculateCycle()
 
     val parsingErrors: List<ParsingError> = scopes.filterIsInstance<ErrorScope>().map { it.parsingError }
 
-    fun getChildEdges(scope: Scope): List<ScopeEdge> {
+    override fun getChildEdges(scope: Scope): List<ScopeEdge> {
         return childEdges[scope] ?: throw NullPointerException("Scope not found: ${scope.qualifiedName}")
     }
 
-    fun getParentEdges(scope: Scope): List<ScopeEdge> {
+    override fun getParentEdges(scope: Scope): List<ScopeEdge> {
         return parentEdges[scope] ?: throw NullPointerException("Scope not found: ${scope.qualifiedName}")
     }
 
-    fun getScope(scopeType: IrType): Scope? {
+    override fun getScope(scopeType: IrType): Scope? {
         return scopeMap[scopeType]
     }
 


### PR DESCRIPTION
ScopeDescriptor is an abstraction to identify what are the roots and children of the scope. By having this abstraction and ScopeGraph its implementation, we can avoid manual delegation.
