### PR TITLE
Remove unused graph parameter from ErrorMessage

### DIFF
--- a/errormessage/src/main/kotlin/motif/errormessage/ErrorHandler.kt
+++ b/errormessage/src/main/kotlin/motif/errormessage/ErrorHandler.kt
@@ -29,7 +29,7 @@ internal interface ErrorHandler {
 
     companion object {
 
-        fun get(graph: ResolvedGraph, error: MotifError): ErrorHandler {
+        fun get(error: MotifError): ErrorHandler {
             return when (error) {
                 is ParsingError -> when (error) {
                     is ScopeMustBeAnInterface -> ScopeMustBeAnInterfaceHandler(error)

--- a/errormessage/src/main/kotlin/motif/errormessage/ErrorMessage.kt
+++ b/errormessage/src/main/kotlin/motif/errormessage/ErrorMessage.kt
@@ -39,14 +39,14 @@ class ErrorMessage(val name: String, val text: String) {
         fun toString(graph: ResolvedGraph): String {
             val content: String = graph.errors.joinToString(
                     "\n------------------------------------\n\n") { error ->
-                val message = ErrorMessage.get(graph, error)
+                val message = get(error)
                 "[${message.name}]\n\n${message.text}"
             }
             return "$header$content$footer"
         }
 
-        fun get(graph: ResolvedGraph, error: MotifError): ErrorMessage {
-            val handler = ErrorHandler.get(graph, error)
+        fun get(error: MotifError): ErrorMessage {
+            val handler = ErrorHandler.get(error)
             val sb = StringBuilder()
             handler.apply {
                 sb.handle()

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopeHierarchyTreeStructure.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopeHierarchyTreeStructure.kt
@@ -117,7 +117,7 @@ class ScopeHierarchyTreeStructure(val project: Project, val graph: ResolvedGraph
             }
             is ScopeHierarchyRootErrorDescriptor -> {
                 graph.errors.forEach { error ->
-                    val errorMessage: ErrorMessage = ErrorMessage.get(graph, error)
+                    val errorMessage: ErrorMessage = ErrorMessage.get(error)
                     descriptors.add(ScopeHierarchyErrorDescriptor(myProject, graph, descriptor, error, errorMessage))
                 }
             }


### PR DESCRIPTION
Graph parameter was never used by getting ErrorMessage, it may be a left-over. All usages show that error list is retrieved from graph and iterated on to call `ErrorMessage.get`. Also by API, it makes more sense that `get` function receives and MotifError and returns a corresponding ErrorMessage.