### PR TITLE
Add search support for the various UI components used in plugin UI

### DIFF
--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/ErrorHierarchyBrowser.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/ErrorHierarchyBrowser.kt
@@ -15,7 +15,6 @@
  */
 package motif.intellij.hierarchy
 
-import com.intellij.ide.hierarchy.HierarchyBrowserBaseEx
 import com.intellij.ide.hierarchy.HierarchyNodeDescriptor
 import com.intellij.ide.hierarchy.HierarchyTreeStructure
 import com.intellij.ide.hierarchy.JavaHierarchyUtil
@@ -47,11 +46,11 @@ import javax.swing.tree.DefaultMutableTreeNode
  * UI component used to render scope properties.
  */
 class ErrorHierarchyBrowser(
-        val project: Project,
+        project: Project,
         initialGraph: ResolvedGraph,
         private val rootElement: PsiElement,
         private val selectionListener: Listener?)
-    : HierarchyBrowserBaseEx(project, rootElement), MotifProjectComponent.Listener {
+    : HierarchyBrowserBase(project, rootElement), MotifProjectComponent.Listener {
 
     private var graph: ResolvedGraph = initialGraph
 

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/HierarchyBrowserBase.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/HierarchyBrowserBase.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.intellij.hierarchy
+
+import com.intellij.ide.hierarchy.HierarchyBrowserBaseEx
+import com.intellij.ide.hierarchy.HierarchyBrowserManager
+import com.intellij.ide.hierarchy.HierarchyNodeRenderer
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.ui.AutoScrollToSourceHandler
+import com.intellij.ui.TreeSpeedSearch
+import com.intellij.ui.treeStructure.Tree
+import com.intellij.util.ui.tree.TreeUtil
+import javax.swing.tree.TreeSelectionModel
+
+/*
+ * Base class for hierarchy browser UI components.
+ *
+ * It enables speed search configurations to search non-expanded nodes too. It is needed when searching for given
+ * scope(s) in the entire graph hierarchy (which can be pretty large).
+ */
+abstract class HierarchyBrowserBase(
+        val project: Project,
+        private val rootElement: PsiElement)
+    : HierarchyBrowserBaseEx(project, rootElement) {
+
+    override fun configureTree(tree: Tree) {
+        // Hack: we're copying code from parent class here, in order to override speed search behavior
+        tree.selectionModel.selectionMode = TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION
+        tree.toggleClickCount = -1
+        tree.cellRenderer = HierarchyNodeRenderer()
+        TreeSpeedSearch(tree, { path -> path.lastPathComponent.toString() }, true)
+        TreeUtil.installActions(tree)
+        object : AutoScrollToSourceHandler() {
+            override fun isAutoScrollMode(): Boolean {
+                return HierarchyBrowserManager.getSettings(myProject).IS_AUTOSCROLL_TO_SOURCE
+            }
+
+            override fun setAutoScrollMode(state: Boolean) {
+                HierarchyBrowserManager.getSettings(myProject).IS_AUTOSCROLL_TO_SOURCE = state
+            }
+        }.install(tree)
+    }
+}

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopeHierarchyBrowser.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopeHierarchyBrowser.kt
@@ -17,7 +17,6 @@ package motif.intellij.hierarchy
 
 import com.intellij.icons.AllIcons
 import com.intellij.ide.IdeBundle
-import com.intellij.ide.hierarchy.HierarchyBrowserBaseEx
 import com.intellij.ide.hierarchy.HierarchyNodeDescriptor
 import com.intellij.ide.hierarchy.HierarchyTreeStructure
 import com.intellij.ide.hierarchy.JavaHierarchyUtil
@@ -56,11 +55,11 @@ import javax.swing.tree.DefaultMutableTreeNode
  * UI component used to render tree of Motif scopes.
  */
 class ScopeHierarchyBrowser(
-        val project: Project,
+        project: Project,
         initialGraph: ResolvedGraph,
         private val rootElement: PsiElement,
         private val selectionListener: Listener?)
-    : HierarchyBrowserBaseEx(project, rootElement), MotifProjectComponent.Listener {
+    : HierarchyBrowserBase(project, rootElement), MotifProjectComponent.Listener {
 
     companion object {
         const val LABEL_GO_PREVIOUS_SCOPE: String = "Go to previous Scope."

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopePropertyHierarchyBrowser.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopePropertyHierarchyBrowser.kt
@@ -50,11 +50,11 @@ import javax.swing.tree.DefaultMutableTreeNode
  * UI component used to render scope properties.
  */
 class ScopePropertyHierarchyBrowser(
-        val project: Project,
+        project: Project,
         initialGraph: ResolvedGraph,
         private val rootElement: PsiElement,
         private val hierarchyType: PropertyHierarchyType)
-    : HierarchyBrowserBaseEx(project, rootElement), MotifProjectComponent.Listener {
+    : HierarchyBrowserBase(project, rootElement), MotifProjectComponent.Listener {
 
     private var graph: ResolvedGraph = initialGraph
 

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/UsageHierarchyBrowser.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/UsageHierarchyBrowser.kt
@@ -41,10 +41,10 @@ import javax.swing.JTree
  * UI component used to render usage.
  */
 class UsageHierarchyBrowser(
-        val project: Project,
+        project: Project,
         initialGraph: ResolvedGraph,
         private val rootElement: PsiElement)
-    : HierarchyBrowserBaseEx(project, rootElement), MotifProjectComponent.Listener {
+    : HierarchyBrowserBase(project, rootElement), MotifProjectComponent.Listener {
 
     private var graph: ResolvedGraph = initialGraph
 

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyDependenciesSectionDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyDependenciesSectionDescriptor.kt
@@ -33,5 +33,9 @@ open class ScopeHierarchyDependenciesSectionDescriptor(
     override fun updateText(text: CompositeAppearance) {
         text.ending.addText(scope.simpleName)
     }
+
+    override fun toString(): String {
+        return scope.simpleName
+    }
 }
 

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyDependencyDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyDependencyDescriptor.kt
@@ -35,5 +35,9 @@ open class ScopeHierarchyDependencyDescriptor(
         text.ending.addText(method.returnType.simpleName)
         text.ending.addText(" (" + formatQualifiedName(method.returnType.qualifiedName) + ")", getPackageNameAttributes())
     }
+
+    override fun toString(): String {
+        return method.returnType.simpleName
+    }
 }
 

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyErrorDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyErrorDescriptor.kt
@@ -130,5 +130,9 @@ open class ScopeHierarchyErrorDescriptor(
     override fun getLegend(): String? {
         return errorMessage.text
     }
+
+    override fun toString(): String {
+        return errorMessage.name
+    }
 }
 

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyScopeDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchyScopeDescriptor.kt
@@ -49,4 +49,8 @@ open class ScopeHierarchyScopeDescriptor(
     override fun getIcon(element: PsiElement): Icon? {
         return AllIcons.Nodes.Interface
     }
+
+    override fun toString(): String {
+        return clazz.name ?: ""
+    }
 }

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchySimpleDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchySimpleDescriptor.kt
@@ -43,4 +43,8 @@ class ScopeHierarchySimpleDescriptor(
     override fun getIcon(element: PsiElement): Icon? {
         return null
     }
+
+    override fun toString(): String {
+        return label
+    }
 }

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchySinkDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchySinkDescriptor.kt
@@ -96,5 +96,9 @@ open class ScopeHierarchySinkDescriptor(
         }
         return null
     }
+
+    override fun toString(): String {
+        return sink.type.simpleName
+    }
 }
 

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchySourceDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchySourceDescriptor.kt
@@ -70,5 +70,9 @@ open class ScopeHierarchySourceDescriptor(
     override fun getIcon(element: PsiElement): Icon? {
         return if (element is PsiClass && element.isInterface) AllIcons.Nodes.Interface else AllIcons.Nodes.Class
     }
+
+    override fun toString(): String {
+        return source.type.simpleName
+    }
 }
 

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchySourcesAndSinksSectionDescriptor.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/descriptor/ScopeHierarchySourcesAndSinksSectionDescriptor.kt
@@ -37,5 +37,9 @@ open class ScopeHierarchySourcesAndSinksSectionDescriptor(
         text.ending.addText(scope.simpleName, TextAttributes(myColor, null, null, null, BOLD))
         text.ending.addText(" (" + formatQualifiedName(scope.qualifiedName) + ")", getPackageNameAttributes())
     }
+
+    override fun toString(): String {
+        return scope.simpleName
+    }
 }
 


### PR DESCRIPTION
This PR is specifying search terms used for string matching for the various nodes in browser hierarchy. 
It also turn on searching on nodes that are not expanded yet.