### PR TITLE
Decrease barrier of entry for contextual menu

### DIFF
--- a/intellij/src/main/kotlin/motif/intellij/MotifProjectComponent.kt
+++ b/intellij/src/main/kotlin/motif/intellij/MotifProjectComponent.kt
@@ -76,6 +76,7 @@ class MotifProjectComponent(val project: Project) : ProjectComponent {
     private var ancestorPanel: MotifScopePanel? = null
     private var ancestorContent: Content? = null
     private var isRefreshing: Boolean = false
+    private var pendingAction: (() -> Unit)? = null
 
     override fun projectOpened() {
         DumbService.getInstance(project).runWhenSmart {
@@ -113,6 +114,11 @@ class MotifProjectComponent(val project: Project) : ProjectComponent {
                 }
             }
         })
+    }
+
+    fun refreshGraph(action: () -> Unit) {
+        pendingAction = action
+        refreshGraph()
     }
 
     fun onSelectedClass(element: PsiElement) {
@@ -183,6 +189,10 @@ class MotifProjectComponent(val project: Project) : ProjectComponent {
                     usageAction.onGraphUpdated(graph)
                 }
             }
+
+            // Execute last pending action
+            pendingAction?.invoke()
+            pendingAction = null
         }
     }
 

--- a/intellij/src/main/kotlin/motif/intellij/ScopeHierarchyUtils.kt
+++ b/intellij/src/main/kotlin/motif/intellij/ScopeHierarchyUtils.kt
@@ -77,6 +77,10 @@ class ScopeHierarchyUtils {
             return element is PsiClass && element.qualifiedName == Object::class.java.name
         }
 
+        fun isInitializedGraph(graph: ResolvedGraph): Boolean {
+            return graph.roots.isNotEmpty()
+        }
+
         fun isMotifScopeClass(element: PsiClass?): Boolean {
             return element?.hasAnnotation(motif.Scope::class.java.name) ?: false
         }


### PR DESCRIPTION
Currently, the menu is grayed out whenever the graph hasn’t been computed. 
This PR changes behavior to have these active all the time, and when menu items are selected while graph hasn’t been computed, we go ahead and compute it and resume menu action.