### PR TITLE
Make IntelliJ plugin more resilient to unknown types

### DIFF
--- a/intellij/ast/src/main/kotlin/motif/ast/intellij/IntelliJClass.kt
+++ b/intellij/ast/src/main/kotlin/motif/ast/intellij/IntelliJClass.kt
@@ -20,20 +20,15 @@ import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.*
 import motif.ast.*
-import java.lang.IllegalStateException
 import kotlin.collections.filter
 import kotlin.collections.map
 
 class IntelliJClass(
         private val project: Project,
-        private val psiClassType: PsiClassType) : IrUtil, IrClass {
+        private val psiClassType: PsiClassType,
+        val psiClass: PsiClass) : IrUtil, IrClass {
 
     private val jvmPsiConversionHelper = ServiceManager.getService(project, JvmPsiConversionHelper::class.java)
-
-    val psiClass: PsiClass by lazy {
-        psiClassType.resolve()
-                ?: throw IllegalStateException(psiClassType.className)
-    }
 
     override val type: IrType by lazy { IntelliJType(project, psiClassType) }
 
@@ -69,7 +64,7 @@ class IntelliJClass(
     override val nestedClasses: List<IrClass> by lazy {
         psiClass.allInnerClasses.map {
             val psiClassType: PsiClassType = PsiElementFactory.SERVICE.getInstance(project).createType(it)
-            IntelliJClass(project, psiClassType)
+            IntelliJClass(project, psiClassType, psiClassType.resolve()!!)
         }
     }
 

--- a/intellij/ast/src/main/kotlin/motif/ast/intellij/IntelliJType.kt
+++ b/intellij/ast/src/main/kotlin/motif/ast/intellij/IntelliJType.kt
@@ -37,7 +37,9 @@ class IntelliJType(
     override val isVoid: Boolean by lazy { psiType == PsiType.VOID }
 
     override fun resolveClass(): IrClass? {
-        return (psiType as? PsiClassType)?.let { IntelliJClass(project, it) }
+        val psiClassType = psiType as? PsiClassType ?: return null
+        val psiClass = psiClassType.resolve() ?: return null
+        return (psiType as? PsiClassType)?.let { IntelliJClass(project, it, psiClass) }
     }
 
     override fun isAssignableTo(type: IrType): Boolean {

--- a/intellij/ast/src/test/kotlin/motif/ast/intellij/IntelliJAnnotationTest.kt
+++ b/intellij/ast/src/test/kotlin/motif/ast/intellij/IntelliJAnnotationTest.kt
@@ -248,7 +248,7 @@ class IntelliJAnnotationTest : LightCodeInsightFixtureTestCase() {
 
     private fun createAnnotationClass(@Language("JAVA") classText: String): IntelliJClass {
         val psiClass = myFixture.addClass(classText)
-        return IntelliJClass(project, psiElementFactory.createType(psiClass))
+        return IntelliJClass(project, psiElementFactory.createType(psiClass), psiClass)
     }
 
     private fun getClassAnnotation(@Language("JAVA") classText: String): IntelliJAnnotation {

--- a/intellij/ast/src/test/kotlin/motif/ast/intellij/IntelliJClassTest.kt
+++ b/intellij/ast/src/test/kotlin/motif/ast/intellij/IntelliJClassTest.kt
@@ -267,7 +267,7 @@ class IntelliJClassTest : LightCodeInsightFixtureTestCase() {
 
     private fun createIntelliJClass(@Language("JAVA") classText: String): IntelliJClass {
         val psiClass = myFixture.addClass(classText)
-        return IntelliJClass(project, psiElementFactory.createType(psiClass))
+        return IntelliJClass(project, psiElementFactory.createType(psiClass), psiClass)
     }
 
     private fun createIntelliJType(classText: String): IntelliJType {

--- a/intellij/src/main/kotlin/motif/intellij/GraphFactory.kt
+++ b/intellij/src/main/kotlin/motif/intellij/GraphFactory.kt
@@ -62,7 +62,7 @@ class GraphFactory(private val project: Project) {
                 .filter(this::isScopeClass)
                 .map(psiElementFactory::createType)
                 .map { type ->
-                    IntelliJClass(project, type)
+                    IntelliJClass(project, type, type.resolve()!!)
                 }
     }
 


### PR DESCRIPTION
In large repositories, it's not uncommon for the IDE to be unable to index some types involved in the DI graph. Previously, we would just blow up with an exception in these cases. This PR allows IntelliJ graph processing to proceed even in the presence of an unknown type. This strategy can lead to unexpected behavior in these cases but seems like a reasonable alternative to crashing the plugin.