### PR TITLE
Fixes to enable Motif Plugin to work on IJ 2018.x

### DIFF
--- a/intellij/src/main/kotlin/motif/intellij/MotifProjectComponent.kt
+++ b/intellij/src/main/kotlin/motif/intellij/MotifProjectComponent.kt
@@ -22,7 +22,6 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.ProjectComponent
-import com.intellij.openapi.extensions.ProjectExtensionPointName
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
@@ -39,7 +38,6 @@ import com.intellij.ui.content.ContentFactory
 import motif.core.ResolvedGraph
 import motif.intellij.analytics.AnalyticsProjectComponent
 import motif.intellij.analytics.MotifAnalyticsActions
-import motif.intellij.analytics.MotifAnalyticsLogger
 import motif.intellij.ui.MotifErrorPanel
 import motif.intellij.ui.MotifScopePanel
 import motif.intellij.ui.MotifUsagePanel

--- a/intellij/src/main/kotlin/motif/intellij/analytics/AnalyticsProjectComponent.kt
+++ b/intellij/src/main/kotlin/motif/intellij/analytics/AnalyticsProjectComponent.kt
@@ -18,14 +18,11 @@ package motif.intellij.analytics
 import com.intellij.openapi.components.ProjectComponent
 import com.intellij.openapi.extensions.ProjectExtensionPointName
 import com.intellij.openapi.project.Project
-import motif.intellij.MotifProjectComponent
 import java.util.*
 
 class AnalyticsProjectComponent(val project: Project) : ProjectComponent {
 
     companion object {
-        private val LOGGER_EXTENSION_POINT_NAME : ProjectExtensionPointName<MotifAnalyticsLogger> =
-                ProjectExtensionPointName("com.uber.motif.motifAnalyticsLogger")
         private val SESSION_ID = UUID.randomUUID()
 
         fun getInstance(project: Project): AnalyticsProjectComponent {
@@ -34,9 +31,15 @@ class AnalyticsProjectComponent(val project: Project) : ProjectComponent {
     }
 
     fun logEvent(action: String) {
-        val metadata: Map<String, String> = mapOf(
-                "SessionId" to SESSION_ID.toString(),
-                "ActionName" to action)
-        LOGGER_EXTENSION_POINT_NAME.getExtensions(project).forEach { it.log(metadata) }
+        try {
+            val metadata: Map<String, String> = mapOf(
+                    "SessionId" to SESSION_ID.toString(),
+                    "ActionName" to action)
+            val projectExtensionPointName: ProjectExtensionPointName<MotifAnalyticsLogger> =
+                    ProjectExtensionPointName("com.uber.motif.motifAnalyticsLogger")
+            projectExtensionPointName.getExtensions(project).forEach { it.log(metadata) }
+        } catch (e: Exception) {
+            // TODO : investigate why ProjectExtensionPointName class can't be loaded with IJ 2018.2
+        }
     }
 }

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopeHierarchyBrowser.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopeHierarchyBrowser.kt
@@ -212,8 +212,7 @@ class ScopeHierarchyBrowser(
         }
 
         override fun update(event: AnActionEvent) {
-            val presentation = event.presentation
-            presentation.isEnabled = hierarchyBase != null && isApplicableElement(hierarchyBase) && hierarchyBase.isValid && !isUpdating()
+            event.presentation.isEnabled = !isUpdating()
         }
     }
 

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopePropertyHierarchyBrowser.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopePropertyHierarchyBrowser.kt
@@ -71,21 +71,13 @@ class ScopePropertyHierarchyBrowser(
         private const val LABEL_NO_SCOPE: String = "No Scope is selected."
     }
 
-    fun setSelectedScope(element: PsiElement) {
-        hierarchyBase = element
-
-        doRefresh(true)
+    init {
         // Expand tree to show items under provides/consumes nodes
         if (hierarchyType == PropertyHierarchyType.CONSUME_AND_PROVIDE) {
             ApplicationManager.getApplication().invokeLater {
                 TreeUtil.expand(currentTree, 2)
             }
         }
-    }
-
-    // HACK: prevent focus to be request when refresh is happening. This is to allow keyboard navigation in scope tree.
-    override fun changeView(typeName: String) {
-        super.changeView(typeName, false)
     }
 
     override fun isApplicableElement(element: PsiElement): Boolean {
@@ -146,10 +138,7 @@ class ScopePropertyHierarchyBrowser(
     }
 
     override fun createHierarchyTreeStructure(typeName: String, psiElement: PsiElement): HierarchyTreeStructure? {
-        if (psiElement == rootElement) {
-            val descriptor: HierarchyNodeDescriptor = ScopeHierarchySimpleDescriptor(project, graph, null, psiElement, LABEL_NO_SCOPE)
-            return ScopeHierarchyTreeStructure(project, graph, descriptor)
-        } else if (psiElement is PsiClass && isMotifScopeClass(psiElement)) {
+        if (psiElement is PsiClass && isMotifScopeClass(psiElement)) {
             val scopeType: PsiType = PsiElementFactory.SERVICE.getInstance(project).createType(psiElement)
             val type: IrType = IntelliJType(project, scopeType)
             val scope: Scope = graph.getScope(type) ?: return null
@@ -171,9 +160,11 @@ class ScopePropertyHierarchyBrowser(
                     ScopeHierarchyTreeStructure(project, graph, descriptor)
                 }
             }
+        } else {
+            val descriptor: HierarchyNodeDescriptor = ScopeHierarchySimpleDescriptor(project, graph, null, psiElement, LABEL_NO_SCOPE)
+            return ScopeHierarchyTreeStructure(project, graph, descriptor)
         }
         return null
-
     }
 
     override fun getBrowserDataKey(): String {

--- a/intellij/src/main/kotlin/motif/intellij/ui/MotifScopePanel.kt
+++ b/intellij/src/main/kotlin/motif/intellij/ui/MotifScopePanel.kt
@@ -21,32 +21,24 @@ import com.intellij.psi.PsiElement
 import com.intellij.ui.components.JBTabbedPane
 import motif.core.ResolvedGraph
 import motif.intellij.MotifProjectComponent
+import motif.intellij.ScopeHierarchyUtils
+import motif.intellij.hierarchy.ScopeHierarchyBrowser
 import motif.intellij.hierarchy.ScopePropertyHierarchyBrowser
 import motif.intellij.hierarchy.ScopePropertyHierarchyBrowser.PropertyHierarchyType
-import motif.intellij.hierarchy.ScopeHierarchyBrowser
-import motif.intellij.ScopeHierarchyUtils
 import motif.models.Scope
 import java.awt.BorderLayout
-import java.awt.Component
 import javax.swing.JPanel
 import javax.swing.JSplitPane
+import javax.swing.JSplitPane.RIGHT
 
-class MotifScopePanel(project: Project, graph: ResolvedGraph) : JPanel(), ScopeHierarchyBrowser.Listener, MotifProjectComponent.Listener {
+class MotifScopePanel(val project: Project, initialGraph: ResolvedGraph) : JPanel(), ScopeHierarchyBrowser.Listener, MotifProjectComponent.Listener {
 
-    companion object {
-        const val USE_TABS: Boolean = false;
-        const val TAB_NAME_CONSUMES: String = "Consumes"
-        const val TAB_NAME_PROVIDES: String = "Provides"
-        const val TAB_NAME_DEPENDENCIES: String = "Dependencies"
-    }
+    private var graph: ResolvedGraph = initialGraph
 
     private val splitPane: JSplitPane
     private val tabs: JBTabbedPane
     private val scopeBrowser: ScopeHierarchyBrowser
-    private val provideBrowser: ScopePropertyHierarchyBrowser
-    private val consumeBrowser: ScopePropertyHierarchyBrowser
-    private val consumeAndProvideBrowser: ScopePropertyHierarchyBrowser
-    private val dependenciesBrowser: ScopePropertyHierarchyBrowser
+    private var consumeAndProvideBrowser: ScopePropertyHierarchyBrowser
 
     init {
         val rootElement: PsiElement = ScopeHierarchyUtils.buildRootElement(project)
@@ -56,27 +48,17 @@ class MotifScopePanel(project: Project, graph: ResolvedGraph) : JPanel(), ScopeH
         scopeBrowser = ScopeHierarchyBrowser(project, graph, rootElement, this)
         scopeBrowser.changeView(ScopeHierarchyBrowser.TYPE_HIERARCHY_TYPE)
 
-        consumeBrowser = buildPropertyHierarchyBrowser(project, graph, rootElement, PropertyHierarchyType.CONSUME)
-        provideBrowser = buildPropertyHierarchyBrowser(project, graph, rootElement, PropertyHierarchyType.PROVIDE)
         consumeAndProvideBrowser = buildPropertyHierarchyBrowser(project, graph, rootElement, PropertyHierarchyType.CONSUME_AND_PROVIDE)
-        dependenciesBrowser = buildPropertyHierarchyBrowser(project, graph, rootElement, PropertyHierarchyType.DEPENDENCIES)
 
         tabs = JBTabbedPane()
-        tabs.addTab(TAB_NAME_CONSUMES, consumeBrowser)
-        tabs.addTab(TAB_NAME_PROVIDES, provideBrowser)
-        tabs.addTab(TAB_NAME_DEPENDENCIES, dependenciesBrowser)
-
-        val bottomComponent: Component = if (USE_TABS) tabs else consumeAndProvideBrowser
-        splitPane = JSplitPane(JSplitPane.VERTICAL_SPLIT, scopeBrowser, bottomComponent)
+        splitPane = JSplitPane(JSplitPane.VERTICAL_SPLIT, scopeBrowser, consumeAndProvideBrowser)
         splitPane.dividerLocation = 250
         add(splitPane)
     }
 
     override fun onGraphUpdated(graph: ResolvedGraph) {
-        provideBrowser.onGraphUpdated(graph)
-        consumeBrowser.onGraphUpdated(graph)
+        this.graph = graph
         consumeAndProvideBrowser.onGraphUpdated(graph)
-        dependenciesBrowser.onGraphUpdated(graph)
         scopeBrowser.onGraphUpdated(graph)
     }
 
@@ -91,10 +73,10 @@ class MotifScopePanel(project: Project, graph: ResolvedGraph) : JPanel(), ScopeH
      * Notify panel that a new scope has been selected in scope hierarchy browser.
      */
     override fun onSelectedScopeChanged(element: PsiElement, scope: Scope) {
-        provideBrowser.setSelectedScope(element)
-        consumeBrowser.setSelectedScope(element)
-        consumeAndProvideBrowser.setSelectedScope(element)
-        dependenciesBrowser.setSelectedScope(element)
+        val previousDividerLocation = splitPane.dividerLocation
+        consumeAndProvideBrowser = buildPropertyHierarchyBrowser(project, graph, element, PropertyHierarchyType.CONSUME_AND_PROVIDE)
+        splitPane.add(consumeAndProvideBrowser, RIGHT)
+        splitPane.dividerLocation = previousDividerLocation
     }
 
     private fun buildPropertyHierarchyBrowser(project: Project, graph: ResolvedGraph, rootElement: PsiElement, type: PropertyHierarchyType): ScopePropertyHierarchyBrowser {


### PR DESCRIPTION
- stop overriding method whose modifiers changed (see https://github.com/JetBrains/intellij-community/commit/e8c2d857b777cd36f72626d869800a2ad848cab8). The alternate fix to the focus issue is to tear down and rebuild the scope property browser swing component, instead of updating it.
- don't use getHierarchyBase() API on browser UI component : this API only exists in IJ 2019+
- try/catch use of extension point API : it throws on 2018.x so we don't want that in a static initializer