### PR TITLE
Scope navigation line markers kotlin support

### DIFF
--- a/intellij/src/main/kotlin/motif/intellij/MotifProjectComponent.kt
+++ b/intellij/src/main/kotlin/motif/intellij/MotifProjectComponent.kt
@@ -18,6 +18,7 @@ package motif.intellij
 import com.intellij.codeInsight.daemon.LineMarkerProviders
 import com.intellij.ide.plugins.PluginManager
 import com.intellij.lang.Language
+import com.intellij.lang.java.JavaLanguage
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.application.ApplicationManager
@@ -41,6 +42,7 @@ import motif.intellij.analytics.MotifAnalyticsActions
 import motif.intellij.ui.MotifErrorPanel
 import motif.intellij.ui.MotifScopePanel
 import motif.intellij.ui.MotifUsagePanel
+import org.jetbrains.kotlin.idea.KotlinLanguage
 
 class MotifProjectComponent(val project: Project) : ProjectComponent {
 
@@ -174,8 +176,8 @@ class MotifProjectComponent(val project: Project) : ProjectComponent {
             errorContent?.displayName = TAB_NAME_ERRORS + " (" + graph.errors.size + ")"
 
             // Propagate changes to line markers provider
-            val language: Language? = Language.findLanguageByID("JAVA")
-            language?.let {
+            val languages: List<Language> = listOf(JavaLanguage.INSTANCE, KotlinLanguage.INSTANCE)
+            languages.forEach {
                 for (lineMarkerProvider in LineMarkerProviders.INSTANCE.allForLanguage(it)) {
                     if (lineMarkerProvider is Listener) {
                         lineMarkerProvider.onGraphUpdated(graph)

--- a/intellij/src/main/kotlin/motif/intellij/PsiUtils.kt
+++ b/intellij/src/main/kotlin/motif/intellij/PsiUtils.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.intellij
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import org.jetbrains.kotlin.asJava.toLightClass
+import org.jetbrains.kotlin.asJava.toLightMethods
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtFunction
+
+internal fun PsiElement.toPsiClass(): PsiElement? {
+    return when (this) {
+        is PsiClass -> this
+        is KtClass -> toLightClass()
+        else -> this
+    }
+}
+
+internal fun PsiElement.toPsiMethod(): PsiElement? {
+    return when (this) {
+        is PsiMethod -> this
+        is KtFunction -> toLightMethods().singleOrNull()
+        else -> this
+    }
+}

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -42,13 +42,17 @@
     </project-components>
 
     <actions>
-        <action class="motif.intellij.actions.MotifGraphAction" description="Display entire Motif graph" id="motif_graph" text="View Graph">
+        <action class="motif.intellij.actions.MotifGraphAction" description="Display entire Motif graph"
+                id="motif_graph" text="View Graph">
             <keyboard-shortcut first-keystroke="control shift G" keymap="$default"/>
         </action>
-        <action class="motif.intellij.actions.MotifAncestorGraphAction" description="Display Motif ancestors graph for this scope" id="motif_ancestor_graph" text="View Scope Ancestors">
+        <action class="motif.intellij.actions.MotifAncestorGraphAction"
+                description="Display Motif ancestors graph for this scope" id="motif_ancestor_graph"
+                text="View Scope Ancestors">
             <keyboard-shortcut first-keystroke="control shift S" keymap="$default"/>
         </action>
-        <action class="motif.intellij.actions.MotifUsageAction" description="Display Motif usage for this object" id="motif_usage" text="Find Usages">
+        <action class="motif.intellij.actions.MotifUsageAction" description="Display Motif usage for this object"
+                id="motif_usage" text="Find Usages">
             <keyboard-shortcut first-keystroke="control shift U" keymap="$default"/>
         </action>
 
@@ -82,9 +86,12 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <codeInsight.lineMarkerProvider language="JAVA"
+                                        implementatgit ionClass="motif.intellij.provider.ScopeNavigationLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="kotlin"
                                         implementationClass="motif.intellij.provider.ScopeNavigationLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="JAVA"
                                         implementationClass="motif.intellij.provider.ScopeHierarchyLineMarkerProvider"/>
+        <!-- TODO: Add kotlin support to ScopeHierarchyLineMarkerProvider -->
     </extensions>
 
     <extensionPoints>


### PR DESCRIPTION
* Register `ScopeNavigationLineMarkerProvider` for Kotlin.
* Update `ScopeNavigationLineMarkerProvider` to support both Kotlin and Java.

<!--
Thank you for contributing to Motif. Before pressing the "Create Pull Request" button, please consider the following
points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
The existing line markers does not support Kotlin, this pull request adds Kotlin support for `ScopeNavigationLineMarkerProvider` which enables to navigate to parent/child scopes through gutter icons. 
<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
https://github.com/uber/motif/issues/192
<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
