### PR TITLE
Remove Jitpack and remove jCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ gradle.startParameter.configureOnDemand = false
 buildscript {
     apply from: 'gradle/dependencies.gradle'
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
     dependencies {
         classpath deps.build.gradlePlugins.android
@@ -21,10 +21,7 @@ subprojects {
     apply from: rootProject.file('gradle/dependencies.gradle')
 
     repositories {
-        jcenter()
         google()
-        // Required until the following is resolved:
-        // https://github.com/tschuchortdev/kotlin-compile-testing/issues/2
-        maven { url 'https://jitpack.io' }
+        mavenCentral()
     }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -61,7 +61,7 @@ ext.deps = [
                 junit: 'junit:junit:4.12',
                 truth: 'com.google.truth:truth:1.0',
                 compileTesting: 'com.google.testing.compile:compile-testing:0.18',
-                compileTestingKotlin: 'com.github.tschuchortdev:kotlin-compile-testing:1.2.1',
+                compileTestingKotlin: 'com.github.tschuchortdev:kotlin-compile-testing:1.2.2',
                 assertj: 'org.assertj:assertj-core:3.13.2'
         ],
         dagger: "com.google.dagger:dagger:${versions.dagger}",

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,8 +25,8 @@ pluginManagement {
         }
     }
     repositories {
-        jcenter()
         google()
+        mavenCentral()
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
There's still one missing dependency required to be in Maven Central (tracked [here](https://youtrack.jetbrains.com/issue/IDEA-261387)). To remove Jitpack, I made a minor version bump 