### PR TITLE
Fix wrong method names generation

### DIFF
--- a/compiler/src/main/kotlin/motif/compiler/Names.kt
+++ b/compiler/src/main/kotlin/motif/compiler/Names.kt
@@ -94,6 +94,7 @@ private object NameVisitor : SimpleTypeVisitor8<String, Void>() {
     }
 
     override fun visitDeclared(t: DeclaredType, p: Void?): String {
+        t.asElement().getKind()
         val simpleName = t.asElement().simpleName.toString()
         val enclosingElementString = t.asElement().enclosingElement.accept(object : SimpleElementVisitor8<String, Void?>() {
 


### PR DESCRIPTION
### TLDR:

There is an edge case where motif would generate dependencies method names of inner classes with a "$" in the method name which could lead to compilation errors.

This simple one line fix will make sure that inner classes that have not been fully resolved by the compiler will be resolved and update their fullName property which is effecting the simpleName value used to generate the method names.

### Deeper dive:

In our case pre compiled class files are passed to the javac classpath, for inner classes the java compiler may resolve the fully qualified name and build the names table in multiple passes.

1. In the first step it will create inner classes with the $, given this is how they are represented in the class file (for example A$B) 

Below is a stacktrace example
```formFullName:745, Symbol$TypeSymbol (com.sun.tools.javac.code)
<init>:1224, Symbol$ClassSymbol (com.sun.tools.javac.code)
enterClass:712, Symtab (com.sun.tools.javac.code)
...
readClassFile:2788, ClassReader (com.sun.tools.javac.jvm)
...
fillIn:348, ClassFinder (com.sun.tools.javac.code)
...
processAnnotations:1209, JavaCompiler (com.sun.tools.javac.main)
```

2. There are a few code paths in the java compiler that will fully resolve the inner class type name as well the enclosing type, the values will be mutated [here](https://github.com/google/error-prone-javac/blob/a53d069bbdb2c60232ed3811c19b65e41c3e60e0/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java#L618).

Below is a stacktrace example:
```
enterClass:612, Symtab (com.sun.tools.javac.code)
enterClass:2630, ClassReader (com.sun.tools.javac.jvm)
readInnerClasses:2729, ClassReader (com.sun.tools.javac.jvm)
read:1120, ClassReader$6 (com.sun.tools.javac.jvm)
readAttrs:1561, ClassReader (com.sun.tools.javac.jvm)
readClassAttrs:1575, ClassReader (com.sun.tools.javac.jvm)
readClass:2681, ClassReader (com.sun.tools.javac.jvm)
readClassBuffer:2775, ClassReader (com.sun.tools.javac.jvm)
readClassFile:2788, ClassReader (com.sun.tools.javac.jvm)
fillIn:348, ClassFinder (com.sun.tools.javac.code)
complete:285, ClassFinder (com.sun.tools.javac.code)
complete:-1, 930579205 (com.sun.tools.javac.code.ClassFinder$$Lambda$1888)
complete:633, Symbol (com.sun.tools.javac.code)
complete:1314, Symbol$ClassSymbol (com.sun.tools.javac.code)
completeEnclosing:322, ClassFinder (com.sun.tools.javac.code)
complete:284, ClassFinder (com.sun.tools.javac.code)
complete:-1, 930579205 (com.sun.tools.javac.code.ClassFinder$$Lambda$1888)
complete:633, Symbol (com.sun.tools.javac.code)
complete:1314, Symbol$ClassSymbol (com.sun.tools.javac.code)
flags:1248, Symbol$ClassSymbol (com.sun.tools.javac.code)
getKind:1381, Symbol$ClassSymbol (com.sun.tools.javac.code)
```

