### PR TITLE
Fix unable to find dependency method

### DIFF
--- a/compiler/ast/src/main/kotlin/motif/ast/compiler/CompilerType.kt
+++ b/compiler/ast/src/main/kotlin/motif/ast/compiler/CompilerType.kt
@@ -35,7 +35,15 @@ class CompilerType(
     }
 
     override val qualifiedName: String by lazy {
-        val candidate = mirror.toString()
+        val candidate = mirror.toString().let {
+            if(it.contains("$") && mirror.kind == TypeKind.DECLARED) {
+                val declaredType: DeclaredType = mirror as DeclaredType
+                declaredType.asElement().kind
+                mirror.toString()
+            } else {
+                it
+            }
+        }
         return@lazy if (candidate.startsWith('(')) {
             candidate.substringAfter(":: ").dropLast(1)
         } else {


### PR DESCRIPTION
**Context**:
This is follow up commit to 6a2e7821ae6ffd41e8bae692a00bb498f9c3541b which should fix another edge case of Motif unable to find a dependency method of inner classes types given their full name value in javac is represented with $.

[ScopeFactoryImpl](https://github.com/uber/motif/blob/0.3.6/compiler/src/main/kotlin/motif/compiler/ScopeImplFactory.kt#L318
) is doing a lookup for a method based on the given Type.

The [methodByType](https://github.com/uber/motif/blob/0.3.6/models/src/main/kotlin/motif/models/Dependencies.kt#L42) map is using  [TreeMap](https://docs.oracle.com/javase/8/docs/api/java/util/TreeMap.html) implementation where keys are matched based on Type's [compareTo](https://github.com/uber/motif/blob/0.3.6/models/src/main/kotlin/motif/models/Type.kt#L38) method, if at some point the Type's [qualifiedName](https://github.com/uber/motif/blob/0.3.6/models/src/main/kotlin/motif/models/Type.kt#L28) is mutated the map would not be able to find the key for the given type.

In the edge case the name will be mutated the same way described in 6a2e7821ae6ffd41e8bae692a00bb498f9c3541b.

**Fix**:
The actual fix is done by calling `declaredType.asElement().kind` which will mutate the fullName property of the type which eventually change the `TypeMirror.toString()` value.

Below is the stacktrace of such change:
```
enterClass:612, Symtab (com.sun.tools.javac.code)
enterClass:2630, ClassReader (com.sun.tools.javac.jvm)
readInnerClasses:2729, ClassReader (com.sun.tools.javac.jvm)
read:1120, ClassReader$6 (com.sun.tools.javac.jvm)
readAttrs:1561, ClassReader (com.sun.tools.javac.jvm)
readClassAttrs:1575, ClassReader (com.sun.tools.javac.jvm)
readClass:2681, ClassReader (com.sun.tools.javac.jvm)
readClassBuffer:2775, ClassReader (com.sun.tools.javac.jvm)
readClassFile:2788, ClassReader (com.sun.tools.javac.jvm)
fillIn:348, ClassFinder (com.sun.tools.javac.code)
complete:285, ClassFinder (com.sun.tools.javac.code)
complete:-1, 930579205 (com.sun.tools.javac.code.ClassFinder$$Lambda$1888)
complete:633, Symbol (com.sun.tools.javac.code)
complete:1314, Symbol$ClassSymbol (com.sun.tools.javac.code)
completeEnclosing:322, ClassFinder (com.sun.tools.javac.code)
complete:284, ClassFinder (com.sun.tools.javac.code)
complete:-1, 930579205 (com.sun.tools.javac.code.ClassFinder$$Lambda$1888)
complete:633, Symbol (com.sun.tools.javac.code)
complete:1314, Symbol$ClassSymbol (com.sun.tools.javac.code)
flags:1248, Symbol$ClassSymbol (com.sun.tools.javac.code)
getKind:1381, Symbol$ClassSymbol (com.sun.tools.javac.code)
```

In order to limit the scope, the if statement is checking for "$" to execute the logic only on inner classes that have not been fully resolved.

