### PR TITLE
Add a minimum test code support on sample apps.

### DIFF
--- a/samples/sample/build.gradle
+++ b/samples/sample/build.gradle
@@ -38,4 +38,7 @@ dependencies {
     implementation deps.stetho
     implementation deps.support.design
     implementation deps.butterknife
+    testImplementation deps.test.truth
+    testImplementation deps.test.junit
+
 }

--- a/samples/sample/src/test/java/motif/sample/app/application/ApplicationTest.java
+++ b/samples/sample/src/test/java/motif/sample/app/application/ApplicationTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.sample.app.application;
+
+import com.google.common.truth.Truth;
+import org.junit.Test;
+
+public class ApplicationTest {
+
+  @Test
+  public void testIt() {
+    Truth.assertThat(1 + 1).isNotEqualTo(3);
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Motif. Before pressing the "Create Pull Request" button, please consider the following
points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Whenever I get a gradle configured project downloaded, I tend to run its minimum unit test example to check out whether the code is compilable with my local environment. And normally, I go to out layer, which is usually the application level to run its java unit test to drive all its dependencies compilation.
However, currently, we do not have such unit test code introduced in the sample app. Hence, I am adding it.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
N/A.

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
