### PR TITLE
Fix an java doc issue triggered during packaging process.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -68,6 +68,7 @@ ext.deps = [
         dagger: "com.google.dagger:dagger:${versions.dagger}",
         daggerCompiler: "com.google.dagger:dagger-compiler:${versions.dagger}",
         javapoet: 'com.squareup:javapoet:1.11.1',
+        javaxInject: 'javax.inject:javax.inject:1',
         kotlinpoet: 'com.squareup:kotlinpoet:1.9.0',
         autoCommon: 'com.google.auto:auto-common:0.10',
         commonsCodec: 'commons-codec:commons-codec:1.13',

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,6 +6,7 @@ targetCompatibility = 1.7
 dependencies {
     // Dagger is part of the API since we generate code which depends on Dagger's API in the consuming gradle module.
     api deps.dagger
+    api deps.javaxInject
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
I am running into the following error when I was executing release script to upload the `uploadArchives`.

> Task :lib:javaJavadoc FAILED
/Users/tonytang/Uber/motif/lib/src/main/java/motif/internal/DaggerScope.java:18: error: package javax.inject does not exist
import javax.inject.Scope;
                   ^
/Users/tonytang/Uber/motif/lib/src/main/java/motif/internal/DaggerScope.java:20: error: cannot find symbol
@ Scope
 ^
  symbol: class Scope



