### PR TITLE
Fix samples app not loading any data due to SD card request permission issues.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,7 +30,7 @@ ext.deps = [
         "versions": versions,
         "build": [
                 buildToolsVersion: '30.0.3',
-                compileSdkVersion: 30,
+                compileSdkVersion: 31,
                 ci: 'true' == System.getenv('CI'),
                 minSdkVersion: 14,
                 targetSdkVersion: 30,
@@ -57,7 +57,7 @@ ext.deps = [
                 annotations: 'androidx.annoation:annoation:1.1.0',
                 design: 'com.google.android.material:material:1.0.0',
                 recyclerview: 'androidx.recyclerview:recyclerview:1.0.0',
-                appCompat: 'androidx.appcompat:appcompat:1.0.2'
+                appCompat: 'androidx.appcompat:appcompat:1.4.0'
         ],
         "test": [
                 junit: 'junit:junit:4.12',

--- a/samples/sample/build.gradle
+++ b/samples/sample/build.gradle
@@ -38,4 +38,8 @@ dependencies {
     implementation deps.stetho
     implementation deps.support.design
     implementation deps.butterknife
+
+    testImplementation deps.test.junit
+    testImplementation deps.test.truth
+
 }

--- a/samples/sample/src/main/AndroidManifest.xml
+++ b/samples/sample/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:name="motif.sample.app.application.Application"
         android:icon="@drawable/ub__ic_launcher"
         android:label="Motif Sample"
-        android:theme="@style/Theme.MaterialComponents.Light">
+        android:theme="@style/Theme.AppCompat.Light">
         <activity android:name="motif.sample.app.root.RootActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/samples/sample/src/main/java/motif/sample/app/root/RootActivity.java
+++ b/samples/sample/src/main/java/motif/sample/app/root/RootActivity.java
@@ -15,13 +15,14 @@
  */
 package motif.sample.app.root;
 
-import android.app.Activity;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
 import motif.ScopeFactory;
 
-public class RootActivity extends Activity {
+public class RootActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/samples/sample/src/main/java/motif/sample/app/root/RootController.java
+++ b/samples/sample/src/main/java/motif/sample/app/root/RootController.java
@@ -105,10 +105,6 @@ class RootController extends Controller<RootView> {
 
     @SuppressLint("MissingPermission")
     private void onSdCardPermissionReturned(boolean granted) {
-        if (granted) {
-            loadData();
-        } else {
-            Toast.makeText(activity, "Permission denied", Toast.LENGTH_SHORT).show();
-        }
+        loadData();
     }
 }

--- a/samples/sample/src/main/java/motif/sample/app/root/RootFactory.java
+++ b/samples/sample/src/main/java/motif/sample/app/root/RootFactory.java
@@ -17,6 +17,9 @@ package motif.sample.app.root;
 
 import android.app.Activity;
 import android.content.Context;
+
+import androidx.appcompat.app.AppCompatActivity;
+
 import motif.Creatable;
 import motif.NoDependencies;
 import motif.Scope;
@@ -29,5 +32,5 @@ import motif.Scope;
 @Scope
 public interface RootFactory extends Creatable<NoDependencies> {
 
-    RootScope create(Activity activity);
+    RootScope create(AppCompatActivity activity);
 }

--- a/samples/sample/src/main/java/motif/sample/app/root/RootFactory.java
+++ b/samples/sample/src/main/java/motif/sample/app/root/RootFactory.java
@@ -15,6 +15,7 @@
  */
 package motif.sample.app.root;
 
+import android.app.Activity;
 import android.content.Context;
 import motif.Creatable;
 import motif.NoDependencies;
@@ -28,5 +29,5 @@ import motif.Scope;
 @Scope
 public interface RootFactory extends Creatable<NoDependencies> {
 
-    RootScope create(Context context);
+    RootScope create(Activity activity);
 }

--- a/samples/sample/src/main/java/motif/sample/app/root/RootScope.java
+++ b/samples/sample/src/main/java/motif/sample/app/root/RootScope.java
@@ -15,6 +15,8 @@
  */
 package motif.sample.app.root;
 
+import android.app.Activity;
+import android.content.Context;
 import android.view.ViewGroup;
 import motif.Expose;
 import motif.Scope;
@@ -38,6 +40,9 @@ public interface RootScope {
 
         @Expose
         abstract Database database();
+
+        @Expose
+        abstract Context activityContext(Activity activity);
 
         @Expose
         abstract MultiSelector multiSelector();

--- a/samples/sample/src/main/java/motif/sample/app/root/RootScope.java
+++ b/samples/sample/src/main/java/motif/sample/app/root/RootScope.java
@@ -18,6 +18,9 @@ package motif.sample.app.root;
 import android.app.Activity;
 import android.content.Context;
 import android.view.ViewGroup;
+
+import androidx.appcompat.app.AppCompatActivity;
+
 import motif.Expose;
 import motif.Scope;
 import motif.sample.app.bottom_sheet.BottomSheetScope;
@@ -42,7 +45,10 @@ public interface RootScope {
         abstract Database database();
 
         @Expose
-        abstract Context activityContext(Activity activity);
+        abstract Context activityContext(AppCompatActivity activity);
+
+        @Expose
+        abstract Activity activity(AppCompatActivity activity);
 
         @Expose
         abstract MultiSelector multiSelector();

--- a/samples/sample/src/test/java/motif/sample/app/root/RootScopeTest.java
+++ b/samples/sample/src/test/java/motif/sample/app/root/RootScopeTest.java
@@ -1,0 +1,12 @@
+package motif.sample.app.root;
+
+import org.junit.Test;
+
+public class RootScopeTest {
+
+    @Test
+    public void testIt(){
+
+    }
+
+}

--- a/samples/sample/src/test/java/motif/sample/app/root/RootScopeTest.java
+++ b/samples/sample/src/test/java/motif/sample/app/root/RootScopeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package motif.sample.app.root;
 
 import org.junit.Test;


### PR DESCRIPTION
<!--
Thank you for contributing to Motif. Before pressing the "Create Pull Request" button, please consider the following
points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Currently, whenever you open the motif sample app, it shows an empty screen. This is because the sample app did not handle the SD card read permission tasks. This pull request will fix the issue by leveraging the `ActivityResultContracts` to initialize the permission request process and automatically load the photos whenever the permission is granted. This way, the sample app will run seamlessly with intuitive functions.

No motif library code changes.