### PR TITLE
Use Java 11 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java_version: [8]
+        java_version: [11]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,4 +31,4 @@ jobs:
         run: ./gradlew check --stacktrace
       - name: Upload Snapshot 
         run: ./gradlew publish --no-daemon --no-parallel -PmavenCentralUsername="${{ secrets.SonatypeUsername }}" -PmavenCentralPassword="${{ secrets.SonatypePassword }}"
-        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.java_version == '8'
+        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.java_version == '11'

--- a/build.gradle
+++ b/build.gradle
@@ -24,4 +24,14 @@ subprojects {
         google()
         mavenCentral()
     }
+
+    configurations.configureEach {
+        resolutionStrategy.eachDependency {
+            if (requested.name.startsWith("kotlin-stdlib")) {
+                useTarget("${requested.group}:${requested.name.replace("jre", "jdk")}:${requested.version}")
+            } else if (requested.group == "org.jetbrains.kotlin") {
+                useVersion(deps.versions.kotlin)
+            }
+        }
+    }
 }

--- a/compiler/ast/src/main/kotlin/motif/ast/compiler/CompilerType.kt
+++ b/compiler/ast/src/main/kotlin/motif/ast/compiler/CompilerType.kt
@@ -46,6 +46,8 @@ class CompilerType(
         }
         return@lazy if (candidate.startsWith('(')) {
             candidate.substringAfter(":: ").dropLast(1)
+        } else if (candidate.startsWith("@")) {
+            candidate.substringAfterLast(" ")
         } else {
             candidate
         }

--- a/compiler/src/test/java/motif/compiler/NamesTest.kt
+++ b/compiler/src/test/java/motif/compiler/NamesTest.kt
@@ -20,6 +20,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.INTERNAL_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import com.tschuchort.compiletesting.SourceFile.Companion.java
 import dagger.shaded.auto.common.AnnotationMirrors
@@ -163,7 +164,7 @@ class NamesTest {
 
     private fun getErrorMessage(classString: String): String {
         val result = compile(SafeNameProcessor(), classString)
-        if (result.exitCode != COMPILATION_ERROR) {
+        if (result.exitCode != COMPILATION_ERROR && result.exitCode != INTERNAL_ERROR) {
             assertWithMessage(result.messages).fail()
         }
         return result.messages

--- a/compiler/src/test/java/motif/compiler/ProGuard.kt
+++ b/compiler/src/test/java/motif/compiler/ProGuard.kt
@@ -31,7 +31,6 @@ import kotlin.reflect.KClass
 object ProGuard {
 
     private val classPathFiles: List<File> by lazy {
-        val rtJar = File(System.getProperty("java.home"), "lib/rt.jar");
         listOf(Scope::class,
                 Truth::class,
                 Inject::class,
@@ -39,7 +38,7 @@ object ProGuard {
                 Component::class,
                 Unit::class,
                 NotNull::class)
-                .map { libraryPath(it) } + rtJar
+                .map { libraryPath(it) }
     }
 
     @JvmStatic

--- a/compiler/src/test/resources/default.pro
+++ b/compiler/src/test/resources/default.pro
@@ -1,3 +1,5 @@
+-libraryjars <java.home>/jmods/java.base.jmod(!**.jar;!module-info.class)
+-optimizations !class/merging/*
 -dontshrink
 -keep class **Test {
     public static void run();

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ def versions = [
         room: '2.4.2',
         dokka: '1.4.32',
         "gradleIntellijPlugin": [
-                ide: '2020.2'
+                ide: '2021.1'
         ],
 ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ def versions = [
         room: '2.4.2',
         dokka: '1.4.32',
         "gradleIntellijPlugin": [
-                ide: '2021.1'
+                ide: '2020.1'
         ],
 ]
 
@@ -63,7 +63,7 @@ ext.deps = [
                 junit: 'junit:junit:4.12',
                 truth: 'com.google.truth:truth:1.0',
                 compileTesting: 'com.google.testing.compile:compile-testing:0.18',
-                compileTestingKotlin: 'com.github.tschuchortdev:kotlin-compile-testing:1.4.2',
+                compileTestingKotlin: 'com.github.tschuchortdev:kotlin-compile-testing:1.4.8',
                 assertj: 'org.assertj:assertj-core:3.13.2'
         ],
         dagger: "com.google.dagger:dagger:${versions.dagger}",

--- a/intellij/ast/build.gradle
+++ b/intellij/ast/build.gradle
@@ -36,4 +36,10 @@ compileTestKotlin {
     }
 }
 
+tasks {
+    buildSearchableOptions {
+        enabled = false
+    }
+}
+
 apply plugin: 'com.vanniktech.maven.publish'

--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -34,4 +34,10 @@ test {
     inputs.files(file("$rootDir/tests/src"))
 }
 
+tasks {
+    buildSearchableOptions {
+        enabled = false
+    }
+}
+
 apply plugin: 'com.vanniktech.maven.publish'

--- a/intellij/testing/build.gradle
+++ b/intellij/testing/build.gradle
@@ -13,3 +13,9 @@ intellij {
 dependencies {
     implementation deps.test.truth
 }
+
+tasks {
+    buildSearchableOptions {
+        enabled = false
+    }
+}

--- a/tests/src/main/java/testcases/T071_scope_factory/config.pro
+++ b/tests/src/main/java/testcases/T071_scope_factory/config.pro
@@ -1,3 +1,4 @@
+-libraryjars <java.home>/jmods/java.base.jmod(!**.jar;!module-info.class)
 -dontshrink
 -keep class **Test {
     public static void run();

--- a/tests/src/main/java/testcases/T072_scope_factory/config.pro
+++ b/tests/src/main/java/testcases/T072_scope_factory/config.pro
@@ -1,3 +1,4 @@
+-libraryjars <java.home>/jmods/java.base.jmod(!**.jar;!module-info.class)
 -dontshrink
 -keep class **Test {
     public static void run();

--- a/tests/src/main/java/testcases/T073_scope_factory_no_dependencies/config.pro
+++ b/tests/src/main/java/testcases/T073_scope_factory_no_dependencies/config.pro
@@ -1,3 +1,4 @@
+-libraryjars <java.home>/jmods/java.base.jmod(!**.jar;!module-info.class)
 -dontshrink
 -keep class **Test {
     public static void run();

--- a/tests/src/main/java/testcases/T074_superclass_nested_class/config.pro
+++ b/tests/src/main/java/testcases/T074_superclass_nested_class/config.pro
@@ -1,3 +1,4 @@
+-libraryjars <java.home>/jmods/java.base.jmod(!**.jar;!module-info.class)
 -dontshrink
 -keep class **Test {
     public static void run();

--- a/tests/src/main/java/testcases/T075_scope_factory_unused_dependencies/config.pro
+++ b/tests/src/main/java/testcases/T075_scope_factory_unused_dependencies/config.pro
@@ -1,3 +1,4 @@
+-libraryjars <java.home>/jmods/java.base.jmod(!**.jar;!module-info.class)
 -dontshrink
 -keep class **Test {
     public static void run();


### PR DESCRIPTION
Run tests using Java 11 and ajdust CompilerType's qualified name since TypeMirror's toString includes type annotations