### PR TITLE
Add KSP & XProcessing deps

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ Releasing
  2. Update the `CHANGELOG.md` for the impending release.
  3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
  4. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
- 5. `./gradlew clean uploadArchives -Dorg.gradle.parallel=false`
+ 5. `CI=true ./gradlew clean publish -Dorg.gradle.parallel=false`
  6. Update the `gradle.properties` to the next SNAPSHOT version.
  7. `git commit -am "Prepare next development version."`
  8. `git push && git push --tags`

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         classpath deps.build.gradlePlugins.android
@@ -14,6 +15,7 @@ buildscript {
         classpath deps.build.gradlePlugins.dokka
         classpath deps.build.gradlePlugins.mavenPublish
         classpath deps.build.gradlePlugins.spotless
+        classpath deps.build.gradlePlugins.shadow
         classpath deps.apacheClient
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,9 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=uber
 POM_DEVELOPER_NAME=Uber Technologies
 
+SONATYPE_HOST=DEFAULT
+RELEASE_SIGNING_ENABLED=true
+
 android.useAndroidX=true
 android.enableJetifier=true
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,12 +16,14 @@
 
 def versions = [
         kotlin: '1.7.10',
+        ksp: '1.7.10-1.0.6',
         ktlint: '0.41.0',
         ktfmt: '0.23',
         dagger: '2.24',
         butterknife: '10.1.0',
         glide: '4.9.0',
         gjf: '1.7',
+        kotlinpoet: '1.10.2',
         room: '2.1.0',
         dokka: '1.4.32',
         "gradleIntellijPlugin": [
@@ -41,6 +43,7 @@ ext.deps = [
                 gradlePlugins: [
                         android: 'com.android.tools.build:gradle:4.2.0',
                         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
+                        ksp: "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:${versions.ksp}",
                         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
                         mavenPublish: 'com.vanniktech:gradle-maven-publish-plugin:0.18.0',
                         spotless: "com.diffplug.spotless:spotless-plugin-gradle:5.11.0",
@@ -68,13 +71,16 @@ ext.deps = [
                 truth: 'com.google.truth:truth:1.0',
                 compileTesting: 'com.google.testing.compile:compile-testing:0.18',
                 compileTestingKotlin: 'com.github.tschuchortdev:kotlin-compile-testing:1.4.9',
+                compileTestingKotlinKsp: 'com.github.tschuchortdev:kotlin-compile-testing-ksp:1.4.9',
                 assertj: 'org.assertj:assertj-core:3.13.2',
         ],
         dagger: "com.google.dagger:dagger:${versions.dagger}",
         daggerCompiler: "com.google.dagger:dagger-compiler:${versions.dagger}",
         javapoet: 'com.squareup:javapoet:1.11.1',
-        kotlinpoet: 'com.squareup:kotlinpoet:1.11.0',
-        autoCommon: 'com.google.auto:auto-common:0.10',
+        kotlinpoet: "com.squareup:kotlinpoet:${versions.kotlinpoet}",
+        kotlinpoetInteropMetadata: "com.squareup:kotlinpoet-metadata:${versions.kotlinpoet}",
+        kotlinxMetadata : 'org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.5.0',
+        autoCommon: 'com.google.auto:auto-common:1.1.2',
         commonsCodec: 'commons-codec:commons-codec:1.13',
         asciiTable: 'de.vandermeer:asciitable:0.3.2',
         butterknife: "com.jakewharton:butterknife:${versions.butterknife}",
@@ -88,4 +94,6 @@ ext.deps = [
         autodispose: 'com.uber.autodispose:autodispose:1.3.0',
         apacheClient: 'org.apache.httpcomponents:httpclient:4.5.9',
         proguard: 'net.sf.proguard:proguard-base:6.2.2',
+        ksp: "com.google.devtools.ksp:symbol-processing-api:jar:${versions.ksp}",
+        kspApi: "com.google.devtools.ksp:symbol-processing-api:${versions.ksp}",
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,7 @@
  */
 
 def versions = [
-        kotlin: '1.6.21',
+        kotlin: '1.7.10',
         ktlint: '0.41.0',
         ktfmt: '0.23',
         dagger: '2.24',
@@ -67,8 +67,8 @@ ext.deps = [
                 junit: 'junit:junit:4.12',
                 truth: 'com.google.truth:truth:1.0',
                 compileTesting: 'com.google.testing.compile:compile-testing:0.18',
-                compileTestingKotlin: 'com.github.tschuchortdev:kotlin-compile-testing:1.4.8',
-                assertj: 'org.assertj:assertj-core:3.13.2'
+                compileTestingKotlin: 'com.github.tschuchortdev:kotlin-compile-testing:1.4.9',
+                assertj: 'org.assertj:assertj-core:3.13.2',
         ],
         dagger: "com.google.dagger:dagger:${versions.dagger}",
         daggerCompiler: "com.google.dagger:dagger-compiler:${versions.dagger}",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -25,6 +25,7 @@ def versions = [
         gjf: '1.7',
         kotlinpoet: '1.10.2',
         room: '2.1.0',
+        roomCompilerProcessing: '2.5.0-alpha03',
         dokka: '1.4.32',
         "gradleIntellijPlugin": [
                 ide: '2020.1'
@@ -74,6 +75,7 @@ ext.deps = [
                 compileTestingKotlin: 'com.github.tschuchortdev:kotlin-compile-testing:1.4.9',
                 compileTestingKotlinKsp: 'com.github.tschuchortdev:kotlin-compile-testing-ksp:1.4.9',
                 assertj: 'org.assertj:assertj-core:3.13.2',
+                roomCompilerProcessingTesting: "androidx.room:room-compiler-processing-testing:${versions.roomCompilerProcessing}",
         ],
         dagger: "com.google.dagger:dagger:${versions.dagger}",
         daggerCompiler: "com.google.dagger:dagger-compiler:${versions.dagger}",
@@ -82,6 +84,7 @@ ext.deps = [
         kotlinpoetInteropMetadata: "com.squareup:kotlinpoet-metadata:${versions.kotlinpoet}",
         kotlinxMetadata : 'org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.5.0',
         autoCommon: 'com.google.auto:auto-common:1.1.2',
+        autoService: "com.google.auto.service:auto-service:1.0",
         commonsCodec: 'commons-codec:commons-codec:1.13',
         asciiTable: 'de.vandermeer:asciitable:0.3.2',
         butterknife: "com.jakewharton:butterknife:${versions.butterknife}",
@@ -92,6 +95,7 @@ ext.deps = [
         roomRx: "androidx.room:room-rxjava2:${versions.room}",
         roomCompiler: "androidx.room:room-compiler:${versions.room}",
         room: "androidx.room:room-runtime:${versions.room}",
+        roomCompilerProcessing: "androidx.room:room-compiler-processing:${versions.roomCompilerProcessing}",
         autodispose: 'com.uber.autodispose:autodispose:1.3.0',
         apacheClient: 'org.apache.httpcomponents:httpclient:4.5.9',
         proguard: 'net.sf.proguard:proguard-base:6.2.2',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -47,6 +47,7 @@ ext.deps = [
                         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
                         mavenPublish: 'com.vanniktech:gradle-maven-publish-plugin:0.18.0',
                         spotless: "com.diffplug.spotless:spotless-plugin-gradle:5.11.0",
+                        shadow: "com.github.jengelman.gradle.plugins:shadow:6.1.0",
                 ]
         ],
         "kotlin": [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopeHierarchyBrowser.kt
+++ b/intellij/src/main/kotlin/motif/intellij/hierarchy/ScopeHierarchyBrowser.kt
@@ -190,6 +190,7 @@ class ScopeHierarchyBrowser(
         status = Status.INITIALIZING
         refresh()
       }
+      else -> {}
     }
 
     MotifProjectComponent.getInstance(project).refreshGraph()

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,6 +46,8 @@ include 'ast'
 include 'tests'
 include 'tests:compiler'
 include 'viewmodel'
+include 'xprocessing'
+include 'xprocessing-testing'
 
 project(':compiler-ast').projectDir = file('compiler/ast')
 project(':intellij-ast').projectDir = file('intellij/ast')

--- a/xprocessing-testing/build.gradle
+++ b/xprocessing-testing/build.gradle
@@ -1,0 +1,47 @@
+plugins {
+    id 'java'
+    id 'com.github.johnrengelman.shadow'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+// create extra configuration for shaded dependencies, so they're not included in the pom
+def shadedConfig = configurations.create('compileShaded')
+shadedConfig.transitive = false
+configurations.compileOnly.extendsFrom(shadedConfig)
+
+dependencies {
+    compileShaded deps.test.roomCompilerProcessingTesting
+}
+
+shadowJar {
+    dependencies {
+        include dependency(deps.test.roomCompilerProcessingTesting)
+    }
+    classifier = ''
+    configurations = [shadedConfig]
+    mergeServiceFiles()
+    relocate 'androidx.room.compiler.processing', 'motif.compiler.processing'
+}
+
+/**
+ * Workaround to add a qualifier to the non-shadowed artifact so that IntelliJ indexes the
+ * shadowed jar properly. This is not done when publishing to avoid having 2 artifacts.
+ *
+ * https://youtrack.jetbrains.com/issue/IDEA-163411/Gradle-integration-is-broken-when-using-the-Shadow-Plugin#focus=Comments-27-5742926.0-0
+ */
+if (System.getenv("CI") == null) {
+    jar {
+        archiveClassifier = 'unshaded'
+    }
+}
+
+artifacts {
+    runtimeOnly shadowJar
+    archives shadowJar
+}
+
+apply plugin: "com.vanniktech.maven.publish"

--- a/xprocessing-testing/gradle.properties
+++ b/xprocessing-testing/gradle.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2022. Uber Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+POM_NAME=Motif
+POM_ARTIFACT_ID=motif-xprocessing-testing
+POM_PACKAGING=jar

--- a/xprocessing/build.gradle
+++ b/xprocessing/build.gradle
@@ -1,0 +1,47 @@
+plugins {
+    id 'java'
+    id 'com.github.johnrengelman.shadow'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+// create extra configuration for shaded dependencies, so they're not included in the pom
+def shadedConfig = configurations.create('compileShaded')
+shadedConfig.transitive = false
+configurations.compileOnly.extendsFrom(shadedConfig)
+
+dependencies {
+    compileShaded deps.roomCompilerProcessing
+}
+
+shadowJar {
+    dependencies {
+        include dependency(deps.roomCompilerProcessing)
+    }
+    classifier = ''
+    configurations = [shadedConfig]
+    mergeServiceFiles()
+    relocate 'androidx.room.compiler.processing', 'motif.compiler.processing'
+}
+
+/**
+ * Workaround to add a qualifier to the non-shadowed artifact so that IntelliJ indexes the
+ * shadowed jar properly. This is not done when publishing to avoid having 2 artifacts.
+ *
+ * https://youtrack.jetbrains.com/issue/IDEA-163411/Gradle-integration-is-broken-when-using-the-Shadow-Plugin#focus=Comments-27-5742926.0-0
+ */
+if (System.getenv("CI") == null) {
+    jar {
+        archiveClassifier = 'unshaded'
+    }
+}
+
+artifacts {
+    runtimeOnly shadowJar
+    archives shadowJar
+}
+
+apply plugin: "com.vanniktech.maven.publish"

--- a/xprocessing/gradle.properties
+++ b/xprocessing/gradle.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2022. Uber Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+POM_NAME=Motif
+POM_ARTIFACT_ID=motif-xprocessing
+POM_PACKAGING=jar


### PR DESCRIPTION
This PR updates some libraries and adds KSP & [XProcessing](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:room/room-compiler-processing/README.md) (a wrapper around AP & KSP APIs) so we can add support for KSP (#211). Two new Gradle modules were added to provide the shaded version of xprocessing per the recommendation of the AndroidX team to avoid conflicts with Room.