### PR TITLE
Add KSP module, processor, and placeholder step

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
     dependencies {
         classpath deps.build.gradlePlugins.android
         classpath deps.build.gradlePlugins.kotlin
+        classpath deps.build.gradlePlugins.ksp
         classpath deps.build.gradlePlugins.dokka
         classpath deps.build.gradlePlugins.mavenPublish
         classpath deps.build.gradlePlugins.spotless

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ subprojects {
                 useTarget("${requested.group}:${requested.name.replace("jre", "jdk")}:${requested.version}")
             } else if (requested.group == "org.jetbrains.kotlin") {
                 useVersion(deps.versions.kotlin)
+            } else if (requested.group == "com.google.auto" && requested.name == "auto-common") {
+                useTarget(deps.autoCommon)
+            } else if (requested.group == "org.jetbrains.kotlinx" && requested.name == "kotlinx-metadata") {
+                useTarget(deps.kotlinxMetadata)
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,27 @@ subprojects {
         }
     }
 
+    afterEvaluate {
+        def extraKotlincArgs = [
+            "-Xjvm-default=all",
+            "-opt-in=kotlin.RequiresOptIn",
+            "-opt-in=kotlin.contracts.ExperimentalContracts",
+        ]
+        if (project.path.startsWith(":compiler")) {
+            extraKotlincArgs += [
+                "-opt-in=motif.compiler.processing.ExperimentalProcessingApi"
+            ]
+        }
+        boolean isKotlinLibrary = project.plugins.hasPlugin("org.jetbrains.kotlin.jvm") || project.plugins.hasPlugin("org.jetbrains.kotlin.android")
+        if (isKotlinLibrary) {
+            it.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+                kotlinOptions {
+                    freeCompilerArgs += extraKotlincArgs
+                }
+            }
+        }
+    }
+
     if (project.path != ":tests") {
         apply plugin: 'com.diffplug.spotless'
         spotless {

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation deps.kotlinpoet
     implementation deps.dagger
     implementation deps.daggerCompiler
+    implementation project(path: ':xprocessing', configuration: 'shadow')
     implementation project(':lib')
     implementation project(':compiler-ast')
     implementation project(':core')

--- a/compiler/ksp/build.gradle
+++ b/compiler/ksp/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+sourceCompatibility = 1.8
+
+dependencies {
+    implementation deps.kotlin.stdlib
+    implementation deps.kotlin.reflection
+    implementation deps.autoCommon
+    implementation deps.autoService
+    implementation deps.commonsCodec
+    implementation deps.kotlinpoet
+    implementation deps.dagger
+    implementation deps.daggerCompiler
+    implementation deps.kspApi
+    implementation project(path: ':xprocessing', configuration: 'shadow')
+    implementation project(':lib')
+    implementation project(':compiler')
+    implementation project(':compiler-ast')
+    implementation project(':core')
+    implementation project(':errormessage')
+
+    testImplementation project(':viewmodel')
+    testImplementation deps.proguard
+    testImplementation deps.test.truth
+    testImplementation deps.test.compileTesting
+    testImplementation deps.test.compileTestingKotlin
+}
+
+apply plugin: 'com.vanniktech.maven.publish'

--- a/compiler/ksp/gradle.properties
+++ b/compiler/ksp/gradle.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2022. Uber Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+POM_NAME=Motif
+POM_ARTIFACT_ID=motif-compiler-ksp
+POM_PACKAGING=jar

--- a/compiler/ksp/src/main/kotlin/com/google/devtools/ksp/KspErrorThrower.kt
+++ b/compiler/ksp/src/main/kotlin/com/google/devtools/ksp/KspErrorThrower.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.devtools.ksp
+
+internal object KspErrorThrower {
+  internal fun rethrowKspError(msg: String) {
+    throw IllegalStateException(msg)
+  }
+}

--- a/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MessageWatcher.kt
+++ b/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MessageWatcher.kt
@@ -16,25 +16,25 @@
 package motif.compiler.ksp
 
 import com.google.devtools.ksp.KspErrorThrower
+import javax.tools.Diagnostic
 import motif.compiler.processing.XAnnotation
 import motif.compiler.processing.XAnnotationValue
 import motif.compiler.processing.XElement
 import motif.compiler.processing.XMessager
-import javax.tools.Diagnostic
 
 /**
- * A message watcher that re-throws exceptions from the KSP devtools package
- * to work around an issue where exceptions are swallowed.
+ * A message watcher that re-throws exceptions from the KSP devtools package to work around an issue
+ * where exceptions are swallowed.
  *
- *  https://github.com/google/ksp/issues/974
+ * https://github.com/google/ksp/issues/974
  */
 internal class MessageWatcher : XMessager() {
   override fun onPrintMessage(
-    kind: Diagnostic.Kind,
-    msg: String,
-    element: XElement?,
-    annotation: XAnnotation?,
-    annotationValue: XAnnotationValue?
+      kind: Diagnostic.Kind,
+      msg: String,
+      element: XElement?,
+      annotation: XAnnotation?,
+      annotationValue: XAnnotationValue?
   ) {
     if (kind == Diagnostic.Kind.ERROR) {
       KspErrorThrower.rethrowKspError(msg)

--- a/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MessageWatcher.kt
+++ b/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MessageWatcher.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler.ksp
+
+import com.google.devtools.ksp.KspErrorThrower
+import motif.compiler.processing.XAnnotation
+import motif.compiler.processing.XAnnotationValue
+import motif.compiler.processing.XElement
+import motif.compiler.processing.XMessager
+import javax.tools.Diagnostic
+
+/**
+ * A message watcher that re-throws exceptions from the KSP devtools package
+ * to work around an issue where exceptions are swallowed.
+ *
+ *  https://github.com/google/ksp/issues/974
+ */
+internal class MessageWatcher : XMessager() {
+  override fun onPrintMessage(
+    kind: Diagnostic.Kind,
+    msg: String,
+    element: XElement?,
+    annotation: XAnnotation?,
+    annotationValue: XAnnotationValue?
+  ) {
+    if (kind == Diagnostic.Kind.ERROR) {
+      KspErrorThrower.rethrowKspError(msg)
+    }
+  }
+}

--- a/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MotifSymbolProcessorProvider.kt
+++ b/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MotifSymbolProcessorProvider.kt
@@ -15,19 +15,19 @@
  */
 package motif.compiler.ksp
 
-import motif.compiler.processing.ExperimentalProcessingApi
-import motif.compiler.processing.XProcessingEnvConfig
-import motif.compiler.processing.ksp.KspBasicAnnotationProcessor
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import motif.compiler.MotifProcessingStep
+import motif.compiler.processing.ExperimentalProcessingApi
+import motif.compiler.processing.XProcessingEnvConfig
+import motif.compiler.processing.ksp.KspBasicAnnotationProcessor
 import motif.core.ResolvedGraph
 
 @AutoService(SymbolProcessorProvider::class)
 class MotifSymbolProcessorProvider(
-  private val config: XProcessingEnvConfig = XProcessingEnvConfig.DEFAULT
+    private val config: XProcessingEnvConfig = XProcessingEnvConfig.DEFAULT
 ) : SymbolProcessorProvider {
   lateinit var graph: ResolvedGraph
 
@@ -37,12 +37,11 @@ class MotifSymbolProcessorProvider(
 
   @OptIn(ExperimentalProcessingApi::class)
   private inner class MotifSymbolProcessor(
-    environment: SymbolProcessorEnvironment,
-    config: XProcessingEnvConfig
+      environment: SymbolProcessorEnvironment,
+      config: XProcessingEnvConfig
   ) : KspBasicAnnotationProcessor(environment, config) {
 
-    override fun processingSteps() = listOf(
-      MotifProcessingStep(graphSetter = { graph = it }, messageWatcher = MessageWatcher())
-    )
+    override fun processingSteps() =
+        listOf(MotifProcessingStep(graphSetter = { graph = it }, messageWatcher = MessageWatcher()))
   }
 }

--- a/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MotifSymbolProcessorProvider.kt
+++ b/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MotifSymbolProcessorProvider.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler.ksp
+
+import motif.compiler.processing.ExperimentalProcessingApi
+import motif.compiler.processing.XProcessingEnvConfig
+import motif.compiler.processing.ksp.KspBasicAnnotationProcessor
+import com.google.auto.service.AutoService
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import motif.compiler.MotifProcessingStep
+import motif.core.ResolvedGraph
+
+@AutoService(SymbolProcessorProvider::class)
+class MotifSymbolProcessorProvider(
+  private val config: XProcessingEnvConfig = XProcessingEnvConfig.DEFAULT
+) : SymbolProcessorProvider {
+  lateinit var graph: ResolvedGraph
+
+  override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+    return MotifSymbolProcessor(environment, config)
+  }
+
+  @OptIn(ExperimentalProcessingApi::class)
+  private inner class MotifSymbolProcessor(
+    environment: SymbolProcessorEnvironment,
+    config: XProcessingEnvConfig
+  ) : KspBasicAnnotationProcessor(environment, config) {
+
+    override fun processingSteps() = listOf(
+      MotifProcessingStep(graphSetter = { graph = it }, messageWatcher = MessageWatcher())
+    )
+  }
+}

--- a/compiler/ksp/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/compiler/ksp/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+motif.compiler.ksp.MotifSymbolProcessorProvider

--- a/compiler/src/main/kotlin/motif/compiler/MotifProcessingStep.kt
+++ b/compiler/src/main/kotlin/motif/compiler/MotifProcessingStep.kt
@@ -24,8 +24,8 @@ import motif.core.ResolvedGraph
 
 @ExperimentalProcessingApi
 class MotifProcessingStep(
-  private val graphSetter: (ResolvedGraph) -> Unit,
-  private val messageWatcher: XMessager? = null,
+    private val graphSetter: (ResolvedGraph) -> Unit,
+    private val messageWatcher: XMessager? = null,
 ) : XProcessingStep {
 
   override fun annotations() = mutableSetOf(motif.Scope::class.qualifiedName!!)

--- a/compiler/src/main/kotlin/motif/compiler/MotifProcessingStep.kt
+++ b/compiler/src/main/kotlin/motif/compiler/MotifProcessingStep.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import motif.compiler.processing.ExperimentalProcessingApi
+import motif.compiler.processing.XElement
+import motif.compiler.processing.XMessager
+import motif.compiler.processing.XProcessingEnv
+import motif.compiler.processing.XProcessingStep
+import motif.core.ResolvedGraph
+
+@ExperimentalProcessingApi
+class MotifProcessingStep(
+  private val graphSetter: (ResolvedGraph) -> Unit,
+  private val messageWatcher: XMessager? = null,
+) : XProcessingStep {
+
+  override fun annotations() = mutableSetOf(motif.Scope::class.qualifiedName!!)
+
+  override fun process(
+      env: XProcessingEnv,
+      elementsByAnnotation: Map<String, Set<XElement>>
+  ): Set<XElement> {
+    messageWatcher?.let { env.messager.addMessageWatcher(messageWatcher) }
+
+    // TODO: implement processor in next PR
+    graphSetter.invoke(ResolvedGraph.create(emptyList()))
+
+    return emptySet()
+  }
+
+  override fun processOver(env: XProcessingEnv, elementsByAnnotation: Map<String, Set<XElement>>) {
+    process(env, elementsByAnnotation)
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,6 +32,7 @@ rootProject.name = 'motif'
 include 'lib'
 include 'compiler'
 include 'compiler-ast'
+include 'compiler-ksp'
 include 'samples:sample'
 include 'samples:sample-lib'
 include 'samples:sample-kotlin'
@@ -50,4 +51,5 @@ include 'xprocessing'
 include 'xprocessing-testing'
 
 project(':compiler-ast').projectDir = file('compiler/ast')
+project(':compiler-ksp').projectDir = file('compiler/ksp')
 project(':intellij-ast').projectDir = file('intellij/ast')


### PR DESCRIPTION
This adds a new Motif KSP compiler artifact, a SymbolProcessingProvider (entry point for KSP), and a placeholder `XProcessingStep` to work towards #211. The step will have logic ported over from the AP processor and its APIs which will then enable AP & KSP to work.