### PR TITLE
Add utilities for Motif KSP using XProcessing

### DIFF
--- a/compiler/ast/build.gradle
+++ b/compiler/ast/build.gradle
@@ -11,11 +11,16 @@ sourceCompatibility = 1.8
 dependencies {
     implementation deps.kotlin.stdlib
     implementation deps.autoCommon
+    implementation deps.javapoet
+    implementation deps.kotlinpoetInteropMetadata
+    implementation deps.kspApi
+    implementation deps.roomCompilerProcessing
 
     api project(':ast')
 
     testImplementation deps.test.truth
     testImplementation deps.test.compileTesting
+    testImplementation deps.test.roomCompilerProcessingTesting
 }
 
 apply plugin: 'com.vanniktech.maven.publish'

--- a/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XAnnotation.kt
+++ b/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XAnnotation.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalProcessingApi::class)
+
+package com.uber.xprocessing.ext
+
+import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XAnnotation
+import androidx.room.compiler.processing.XAnnotationValue
+import androidx.room.compiler.processing.XProcessingEnv
+import androidx.room.compiler.processing.compat.XConverters.toJavac
+import com.google.auto.common.AnnotationMirrors
+
+/**
+ * Used to find equivalence of two XAnnotation since AnnotationMirrors.equivalence() only applies to
+ * the Javac backend.
+ */
+fun XAnnotation.isEquivalent(other: XAnnotation, env: XProcessingEnv): Boolean {
+  return if (env.backend == XProcessingEnv.Backend.JAVAC) {
+    val key = AnnotationMirrors.equivalence().wrap(this.toJavac())
+    val otherKey = AnnotationMirrors.equivalence().wrap(other.toJavac())
+    key == otherKey
+  } else {
+    (type.isEquivalent(other.type, env) &&
+        annotationValues.size == other.annotationValues.size &&
+        annotationValues.zip(other.annotationValues).all { (lhs, rhs) -> lhs.isEquivalent(rhs) })
+  }
+}
+
+/**
+ * Used to find equivalence of two XAnnotation since AnnotationMirrors.equivalence() only applies to
+ * the Javac backend.
+ */
+fun XAnnotationValue.isEquivalent(other: XAnnotationValue): Boolean {
+  return this.name == other.name && this.value == other.value
+}
+
+/** Cleans up differences in the toString() methods between the JAVAC and KSP backends. */
+fun XAnnotation.toPrettyString(): String {
+  val annotationValues =
+      this.annotationValues
+          .map {
+            if (it.name == "value") {
+              "\"${it.value}\""
+            } else "${it.name} = ${it.value}"
+          }
+          .joinToString(", ")
+  val annotationValuesList =
+      if (this.annotationValues.isNotEmpty()) {
+        "($annotationValues)"
+      } else {
+        ""
+      }
+  return "@${this.qualifiedName}$annotationValuesList"
+}

--- a/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XElement.kt
+++ b/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XElement.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.xprocessing.ext
+
+import androidx.room.compiler.processing.XElement
+import androidx.room.compiler.processing.XHasModifiers
+import androidx.room.compiler.processing.XMethodElement
+import javax.lang.model.element.Modifier
+
+val XElement.modifiers: List<Modifier>
+  get() {
+    return (this as? XHasModifiers)?.let {
+      val modifiers = mutableListOf<Modifier>()
+      if (isPublic()) modifiers += Modifier.PUBLIC
+      if (isProtected()) modifiers += Modifier.PROTECTED
+      if (isPrivate()) modifiers += Modifier.PRIVATE
+      if (isAbstract()) modifiers += Modifier.ABSTRACT
+      if (this is XMethodElement && isJavaDefault()) modifiers += Modifier.DEFAULT
+      if (isStatic()) modifiers += Modifier.STATIC
+      if (isFinal()) modifiers += Modifier.FINAL
+      if (isTransient()) modifiers += Modifier.TRANSIENT
+      return@let modifiers
+    }
+        ?: emptyList()
+  }
+
+val XElement.modifierNames: List<String>
+  get() = modifiers.map { it.name }
+
+fun XHasModifiers.isPackagePrivate(): Boolean {
+  return !isPrivate() && !isProtected() && !isPublic()
+}

--- a/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XOverrides.kt
+++ b/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XOverrides.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.xprocessing.ext
+
+import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XMethodElement
+import androidx.room.compiler.processing.XProcessingEnv
+import androidx.room.compiler.processing.XTypeElement
+import androidx.room.compiler.processing.compat.XConverters.toJavac
+import androidx.room.compiler.processing.compat.XConverters.toKS
+import com.google.auto.common.MoreElements
+import com.uber.xprocessing.ext.XOverrides.overrides
+
+/**
+ * A semi-port of [Overrides] from AutoCommon using the XProcessing APIs.
+ * https://github.com/google/auto/blob/master/common/src/main/java/com/google/auto/common/Overrides.java
+ *
+ * Determines if one method overrides another. This class defines two ways of doing that:
+ * [NativeOverrides] uses the method [Elements.overrides] while [ExplicitOverrides] reimplements
+ * that method in a way that is more consistent between compilers, in particular between javac and
+ * ecj (the Eclipse compiler).
+ */
+@OptIn(ExperimentalProcessingApi::class)
+object XOverrides {
+  fun overrides(
+      overrider: XMethodElement,
+      overridden: XMethodElement,
+      inType: XTypeElement,
+      env: XProcessingEnv,
+      useMoreElements: Boolean = true,
+  ): Boolean {
+    if (useMoreElements) {
+      return when (env.backend) {
+        XProcessingEnv.Backend.JAVAC -> {
+          MoreElements.overrides(
+              overrider.toJavac(), overridden.toJavac(), inType.toJavac(), env.toJavac().typeUtils)
+          false
+        }
+        XProcessingEnv.Backend.KSP -> {
+          env.resolver()?.overrides(overrider.toKS(), overridden.toKS(), inType.toKS()) ?: false
+        }
+      }
+    }
+
+    if (overrider.name != overridden.name) {
+      // They must have the same name.
+      return false
+    }
+    // We should just be able to write overrider.equals(overridden) here, but that runs afoul
+    // of a problem with Eclipse. If for example you look at the method Stream<E> stream() in
+    // Collection<E>, as obtained by collectionTypeElement.getEnclosedElements(), it will not
+    // compare equal to the method Stream<E> stream() as obtained by
+    // elementUtils.getAllMembers(listTypeElement), even though List<E> inherits the method
+    // from Collection<E>. The reason is that, in ecj, getAllMembers does type substitution,
+    // so the return type of stream() is Stream<E'>, where E' is the E from List<E> rather than
+    // the one from Collection<E>. Instead we compare the enclosing element, which will be
+    // Collection<E> no matter how we got the method. If two methods are in the same type
+    // then it's impossible for one to override the other, regardless of whether they are the
+    // same method.
+    if (overrider.enclosingElement == overridden.enclosingElement) {
+      return false
+    }
+    if (overridden.isStatic()) {
+      // Static methods can't be overridden (though they can be hidden by other static methods).
+      return false
+    }
+    val overriddenVisibility: Visibility = Visibility.of(overridden)
+    val overriderVisibility: Visibility = Visibility.of(overrider)
+    if (overridden.isPrivate() || overriderVisibility.compareTo(overriddenVisibility) < 0) {
+      // Private methods can't be overridden, and methods can't be overridden by less-visible
+      // methods. The latter condition is enforced by the compiler so in theory we might report
+      // an "incorrect" result here for code that javac would not have allowed.
+      return false
+    }
+    // TODO: do this right (added by me)
+    if (overrider.parameters.size != overridden.parameters.size) {
+      return false
+    }
+    for (i in overrider.parameters.indices) {
+      if (!overrider.parameters[i].type.isSameType(overridden.parameters[i].type)) {
+        return false
+      }
+    }
+    val overriddenType = overridden.enclosingElement as? XTypeElement
+    return if (inType.isClass()) {
+      // Method mC in or inherited by class C (JLS 8.4.8.1)...
+      if (overriddenType?.isClass() == true) {
+        // ...overrides from C another method mA declared in class A. The only condition we
+        // haven't checked is that C does not inherit mA. Ideally we could just write this:
+        //    return !elementUtils.getAllMembers(in).contains(overridden);
+        // But that doesn't work in Eclipse. For example, getAllMembers(AbstractList)
+        // contains List.isEmpty() where you might reasonably expect it to contain
+        // AbstractCollection.isEmpty(). So we need to visit superclasses until we reach
+        // one that declares the same method, and check that we haven't reached mA. We compare
+        // the enclosing elements rather than the methods themselves for the reason described
+        // at the start of the method.
+        var inherited: XMethodElement? = null
+        (inherited != null && overridden.enclosingElement != inherited.enclosingElement)
+      } else if (overriddenType?.isInterface() == true) {
+        // ...overrides from C another method mI declared in interface I. We've already checked
+        // the conditions (assuming that the only alternative to mI being abstract or default is
+        // mI being static, which we eliminated above). However, it appears that the logic here
+        // is necessary in order to be compatible with javac's `overrides` method. An inherited
+        // abstract method does not override another method. (But, if it is not inherited,
+        // it does, including if inType inherits a concrete method of the same name from its
+        // superclass.) Here again we can use getAllMembers with javac but not with ecj. javac
+        // says that getAllMembers(AbstractList) contains both AbstractCollection.size() and
+        // List.size(), but ecj doesn't have the latter. The spec is not particularly clear so
+        // either seems justifiable. So we need to look up the interface path that goes from inType
+        // to `overriddenType` (or the several paths if there are several) and apply similar logic
+        // to methodFromSuperclasses above.
+        if (overrider.isAbstract()) {
+          var inherited: XMethodElement? = null
+          (inherited != null && overridden.enclosingElement != inherited.enclosingElement)
+        } else {
+          true
+        }
+      } else {
+        // We don't know what this is so say no.
+        false
+      }
+    } else {
+      overriddenType?.isInterface() == true
+      // Method mI in or inherited by interface I (JLS 9.4.1.1). We've already checked everything.
+      // If this is not an interface then we don't know what it is so we say no.
+    }
+  }
+}
+
+enum class Visibility {
+  PRIVATE,
+  DEFAULT,
+  PROTECTED,
+  INTERNAL,
+  PUBLIC;
+
+  companion object {
+    fun of(element: XMethodElement) =
+        when {
+          element.isPrivate() -> PRIVATE
+          element.isProtected() -> PROTECTED
+          element.returnType.isInternal() -> INTERNAL
+          element.isPublic() -> PUBLIC
+          else -> DEFAULT
+        }
+  }
+}

--- a/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XProcessingEnv.kt
+++ b/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XProcessingEnv.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalProcessingApi::class)
+
+package com.uber.xprocessing.ext
+
+import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XProcessingEnv
+import com.google.devtools.ksp.processing.Resolver
+
+val XProcessingEnv.typeUtils
+  get() = XTypeUtils
+
+/** Provides access to KSP's resolver since XProcessing does not give us access */
+fun XProcessingEnv.resolver(): Resolver? {
+  return if (backend == XProcessingEnv.Backend.KSP) {
+    Class.forName("androidx.room.compiler.processing.ksp.KspProcessingEnv")
+        ?.getDeclaredField("_resolver")
+        ?.apply { isAccessible = true }
+        ?.get(this) as
+        Resolver?
+  } else {
+    null
+  }
+}

--- a/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XType.kt
+++ b/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XType.kt
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalProcessingApi::class)
+
+package com.uber.xprocessing.ext
+
+import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XNullability
+import androidx.room.compiler.processing.XProcessingEnv
+import androidx.room.compiler.processing.XType
+import androidx.room.compiler.processing.compat.XConverters.toJavac
+import androidx.room.compiler.processing.compat.XConverters.toKS
+import androidx.room.compiler.processing.compat.XConverters.toXProcessing
+import androidx.room.compiler.processing.isEnum
+import com.google.auto.common.MoreTypes
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getJavaClassByName
+import com.google.devtools.ksp.isInternal
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSType
+import com.squareup.javapoet.ParameterizedTypeName
+import com.squareup.javapoet.TypeName
+import com.squareup.javapoet.WildcardTypeName
+import javax.lang.model.type.DeclaredType
+
+/**
+ * Since Motif builds the entire ScopeGraph for every module, there are often cases where it is
+ * operating on types that are not on the classpath (esp due to ABIs). Because of this, we can only
+ * rely on the information provided to us by the toString() of the XType. This adds special handling
+ * of the qualified name for various cases to ensure that similar types match.
+ */
+fun XType.qualifiedName(env: XProcessingEnv): String {
+  val mirror = this
+  val candidate =
+      if (mirror.toString().contains("$") && mirror.isDeclaredType()) {
+        (mirror as? DeclaredType)?.asElement()?.kind
+        mirror.toString()
+      } else {
+        when (env.backend) {
+          XProcessingEnv.Backend.JAVAC -> mirror.toString()
+          XProcessingEnv.Backend.KSP -> {
+            if ("NonExistentClass" in mirror.typeName.toString()) {
+              // Type contains class not on classpath, so we can't make use of TypeName
+              val decl = mirror.toKS().declaration
+              val packageName = decl.packageName.asString()
+              val simpleName = decl.simpleName.asString()
+              val args =
+                  if ('<' in mirror.toString()) {
+                        mirror.toString().substring(mirror.toString().indexOf('<'))
+                      } else {
+                        ""
+                      }
+                      .replace("\\.\\.[A-Za-z0-9._-]+\\?".toRegex(), "")
+                      .replace("(", "")
+                      .replace(")", "")
+              "$packageName.$simpleName$args".replace("? extends ", "").replace("? super ", "")
+            } else if (mirror.typeName.containsWildcardType()) {
+              mirror.typeName.removeWildcardType().toString()
+            } else {
+              mirror.typeName.toString()
+            }
+          }
+        }
+      }
+
+  return if (candidate.startsWith('(')) {
+    candidate.substringAfter(":: ").dropLast(1)
+  } else if (candidate.startsWith("@")) {
+    candidate.substringAfterLast(" ")
+  } else {
+    candidate
+  }
+}
+
+/** Recursively checks the parts of the TypeName checking for existence of a wildcard type. */
+fun TypeName.containsWildcardType(): Boolean {
+  return when (this) {
+    is WildcardTypeName -> true
+    is ParameterizedTypeName -> return this.typeArguments.any { it.containsWildcardType() }
+    else -> false
+  }
+}
+
+/** Returns a TypeName with any Wildcard types recursively removed. */
+fun TypeName.removeWildcardType(): TypeName {
+  return when (this) {
+    is WildcardTypeName -> this.upperBounds.first() ?: TypeName.OBJECT
+    is ParameterizedTypeName -> {
+      val args = this.typeArguments.map { it.removeWildcardType() }.toTypedArray()
+      ParameterizedTypeName.get(this.rawType, *args)
+    }
+    else -> this
+  }
+}
+
+fun TypeName.removeWildcardTypeIfContains(): TypeName {
+  return if (this.containsWildcardType()) this.removeWildcardType() else this
+}
+
+/**
+ * This adds extra handling to Java TypeNames so that when it is based on an XType that has type
+ * parameters, we add the necessary wildcards so that we use a non-raw type so we are compatible
+ * with Kotlin types.
+ */
+fun com.squareup.javapoet.TypeName.withRawTypeFix(
+    env: XProcessingEnv
+): com.squareup.javapoet.TypeName {
+  if (env.backend == XProcessingEnv.Backend.JAVAC) {
+    return when (this) {
+      is ParameterizedTypeName -> {
+        val args = this.typeArguments.map { it.withRawTypeFix(env) }.toTypedArray()
+        ParameterizedTypeName.get(this.rawType, *args)
+      }
+      is com.squareup.javapoet.ClassName -> {
+        val mirror = env.findType(this.toString())
+        if (mirror != null && mirror.typeArguments.isNotEmpty() && "<" !in this.toString()) {
+          val args =
+              mirror
+                  .typeArguments
+                  .map { WildcardTypeName.subtypeOf(com.squareup.javapoet.TypeName.OBJECT) }
+                  .toTypedArray()
+          ParameterizedTypeName.get(this, *args)
+        } else {
+          this
+        }
+      }
+      else -> this
+    }
+  }
+  return this
+}
+
+/**
+ * Used to find equivalence of two XType since MoreTypes.equivalence() only applies to the Javac
+ * backend.
+ */
+fun XType.isEquivalent(other: XType, env: XProcessingEnv): Boolean {
+  return when (env.backend) {
+    XProcessingEnv.Backend.JAVAC -> {
+      val key = MoreTypes.equivalence().wrap(this.toJavac())
+      val otherKey = MoreTypes.equivalence().wrap(other.toJavac())
+      key == otherKey
+    }
+    XProcessingEnv.Backend.KSP -> {
+      if ("NonExistentClass" in typeName.toString() ||
+          "NonExistentClass" in other.typeName.toString()) {
+        this.qualifiedName(env) == other.qualifiedName(env)
+      } else {
+        this.typeName.removeWildcardTypeIfContains() ==
+            other.typeName.removeWildcardTypeIfContains()
+      }
+    }
+  }
+}
+
+/**
+ * Used to find the hash of an XType since MoreTypes.equivalence().hashCode() only applies to the
+ * Javac backend.
+ */
+fun XType.hash(): Int {
+  return try {
+    MoreTypes.equivalence().wrap(this.toJavac()).hashCode()
+  } catch (t: Throwable) {
+    if (typeArguments.any { it.typeName is WildcardTypeName && it.typeName.toString() != "?" }) {
+      extendsBoundOrSelf().typeName.toString().hashCode()
+    } else if (this.hasCollectionType()) {
+      typeName.removeWildcardTypeIfContains().toString().hashCode()
+    } else {
+      hashCode()
+    }
+  }
+}
+
+fun XType.isInternal(): Boolean {
+  val ksType =
+      try {
+        Class.forName("androidx.room.compiler.processing.ksp.KspType")
+            ?.getDeclaredField("ksType")
+            ?.apply { isAccessible = true }
+            ?.get(this) as?
+            KSType
+      } catch (throwable: Throwable) {
+        null
+      }
+  val isTypeInternal = ksType?.declaration?.isInternal() ?: false
+  return isTypeInternal || typeArguments.any { it.isInternal() }
+}
+
+fun KSType.isRaw(): Boolean {
+  // yes this is gross but KSP itself seems to be doing it as well
+  // https://github.com/google/ksp/blob/main/compiler-plugin/
+  // src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt#L85
+  return toString().startsWith("raw ")
+}
+
+fun XType.makeNonNullByDefault(): XType {
+  return if (nullability == XNullability.UNKNOWN) makeNonNullable() else this
+}
+
+@OptIn(KspExperimental::class)
+fun XType.mapToJavaType(env: XProcessingEnv): XType {
+  if (env.backend == XProcessingEnv.Backend.KSP) {
+    val resolver = env.resolver() ?: return this
+    val mappedType =
+        if (this.typeArguments.isEmpty()) {
+          env.resolver()
+              ?.getJavaClassByName(toKS().declaration.qualifiedName?.asString().orEmpty())
+              ?.toXProcessing(env)
+              ?.type
+              ?: return this
+        } else {
+          val rawTypeName =
+              resolver.mapKotlinNameToJava(
+                  typeElement?.type?.toKS()?.declaration?.qualifiedName?.asString().orEmpty())
+          val rawType =
+              env.resolver()?.getJavaClassByName(rawTypeName)?.toXProcessing(env) ?: return this
+          val types =
+              typeArguments
+                  .map {
+                    val typeArgName =
+                        resolver.mapKotlinNameToJava(
+                            it.toKS().declaration.qualifiedName?.asString().orEmpty())
+                    env.resolver()?.getJavaClassByName(typeArgName)?.toXProcessing(env)?.type
+                        ?: return this
+                  }
+                  .toTypedArray()
+          env.getDeclaredType(rawType, *types)
+        }
+    if ("NonExistentClass" !in mappedType.toString()) {
+      return mappedType
+    }
+  }
+  return this
+}
+
+fun XType.mapToKotlinType(env: XProcessingEnv): XType {
+  if (env.backend == XProcessingEnv.Backend.KSP) {
+    val resolver = env.resolver() ?: return this
+    val rawTypeName = resolver.mapJavaNameToKotlin(rawType.toString())
+    val mappedType =
+        if (this.typeArguments.isEmpty()) {
+          env.findType(rawTypeName) ?: return this
+        } else {
+          val rawType = env.findTypeElement(rawTypeName) ?: return this
+          val types =
+              typeArguments
+                  .map {
+                    val typeArgName = resolver.mapJavaNameToKotlin(it.qualifiedName(env))
+                    env.findType(typeArgName) ?: return this
+                  }
+                  .toTypedArray()
+          env.getDeclaredType(rawType, *types)
+        }
+    if ("NonExistentClass" !in mappedType.toString()) {
+      return mappedType
+    }
+  }
+  return this
+}
+
+@OptIn(KspExperimental::class)
+internal fun Resolver.mapKotlinNameToJava(qualifiedName: String): String {
+  val ksName = this.getKSNameFromString(qualifiedName)
+  return mapKotlinNameToJava(ksName)?.asString() ?: qualifiedName
+}
+
+@OptIn(KspExperimental::class)
+internal fun Resolver.mapJavaNameToKotlin(qualifiedName: String): String {
+  val ksName = this.getKSNameFromString(qualifiedName)
+  return mapJavaNameToKotlin(ksName)?.asString() ?: qualifiedName
+}
+
+fun XType.isDeclaredType(): Boolean {
+  return typeElement?.let {
+    when {
+      it.isClass() -> true
+      it.isInterface() -> true
+      it.isEnum() -> true
+      it.isAnnotationClass() -> true
+      it.isKotlinObject() -> true
+      else -> false
+    }
+  }
+      ?: false
+}
+
+fun XType.isEnum(): Boolean {
+  return typeElement?.let { it.isEnum() } ?: false
+}
+
+fun XType.isPrimitive(): Boolean {
+  return typeName.isPrimitive
+}
+
+private fun XType.hasCollectionType(): Boolean {
+  return this.typeElement?.name.orEmpty() in collectionTypes ||
+      typeArguments.any { it.hasCollectionType() }
+}
+
+private val collectionTypes =
+    setOf("MutableList", "MutableSet", "MutableCollection", "List", "Set", "Collection")

--- a/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XTypeElement.kt
+++ b/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XTypeElement.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalProcessingApi::class)
+
+package com.uber.xprocessing.ext
+
+import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XMethodElement
+import androidx.room.compiler.processing.XProcessingEnv
+import androidx.room.compiler.processing.XTypeElement
+import androidx.room.compiler.processing.compat.XConverters.toJavac
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.LinkedHashMultimap
+import com.google.common.collect.SetMultimap
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import com.squareup.kotlinpoet.metadata.toKmClass
+import motif.ast.compiler.CompilerClass
+
+/**
+ * A port of MoreElements.getLocalAndInheritedMethods() using XProcessing APIs.
+ * https://github.com/google/auto/blob/master/common/src/main/java/com/google/auto/common/MoreElements.java#L394
+ */
+fun XTypeElement.getLocalAndInheritedMethods(
+    env: XProcessingEnv,
+    useMoreElements: Boolean = true
+): List<XMethodElement> {
+  val nonPrivateInstanceMethods =
+      this.getAllNonPrivateInstanceMethods()
+          .filter {
+            !it.isPrivate() &&
+                it.enclosingElement.toString() !in CompilerClass.TOP_LEVEL_OBJECT_NAMES
+          }
+          .filterNot {
+            it.isPackagePrivate() &&
+                it.enclosingElement.className.packageName() != this.className.packageName()
+          }
+  val methodMap: SetMultimap<String, XMethodElement> = LinkedHashMultimap.create()
+  nonPrivateInstanceMethods.forEach { methodMap.put(it.name, it) }
+
+  val overridden: LinkedHashSet<XMethodElement> = LinkedHashSet()
+  for (methods in methodMap.asMap().values) {
+    val methodList: List<XMethodElement> = ImmutableList.copyOf(methods)
+    for (i in methodList.indices) {
+      val methodI = methodList[i]
+      for (j in i + 1 until methodList.size) {
+        val methodJ = methodList[j]
+        if (methodJ.overrides(methodI, this) ||
+            XOverrides.overrides(methodJ, methodI, this, env, useMoreElements)) {
+          overridden.add(methodI)
+        }
+      }
+    }
+  }
+  val methods: MutableSet<XMethodElement> = LinkedHashSet(methodMap.values())
+  methods.removeAll(overridden)
+  return methods.toList()
+}
+
+/** Return where or not this XTypeElement was from an XType defined in Kotlin */
+@OptIn(KotlinPoetMetadataPreview::class)
+fun XTypeElement?.isKotlinSource(env: XProcessingEnv): Boolean {
+  return when (env.backend) {
+    XProcessingEnv.Backend.JAVAC ->
+        try {
+          this?.toJavac()?.toKmClass() != null
+        } catch (e: Throwable) {
+          false
+        }
+    XProcessingEnv.Backend.KSP -> true
+  }
+}

--- a/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XTypeUtils.kt
+++ b/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XTypeUtils.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalProcessingApi::class)
+
+package com.uber.xprocessing.ext
+
+import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XProcessingEnv
+import androidx.room.compiler.processing.XType
+
+/** Provides additional utils that the JAVAC backend usually gets from TypeUtils. */
+object XTypeUtils {
+  fun isAssignable(t1: XType, t2: XType) = t2.isAssignableFrom(t1)
+
+  fun isSameType(t1: XType, t2: XType) = t1.isSameType(t2)
+
+  fun directSupertypes(t: XType) = t.superTypes
+
+  fun erasure(t: XType, env: XProcessingEnv) =
+      if (t.typeArguments.isNotEmpty()) {
+        env.findTypeElement(t.rawType.toString())?.type
+        t.typeElement?.let { env.getDeclaredType(it) } ?: t
+      } else {
+        t
+      }
+}

--- a/compiler/ast/src/main/kotlin/motif/ast/compiler/CompilerClass.kt
+++ b/compiler/ast/src/main/kotlin/motif/ast/compiler/CompilerClass.kt
@@ -111,4 +111,8 @@ class CompilerClass(override val env: ProcessingEnvironment, val declaredType: D
 
     return fields
   }
+
+  companion object {
+    internal val TOP_LEVEL_OBJECT_NAMES = setOf("java.lang.Object", "kotlin.Any", "Any", "Object")
+  }
 }


### PR DESCRIPTION
Adds various utilities that will be needed in #211. Most extension functions are porting AutoCommon logic to XProcessing APIs or fixing inconsistencies in toString() behavior between the JAVAC and KSP backends.