### PR TITLE
Add XProcessing utils for codegen

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation deps.kotlinpoet
     implementation deps.dagger
     implementation deps.daggerCompiler
+    implementation deps.kspApi
     implementation deps.roomCompilerProcessing
     implementation project(':lib')
     implementation project(':compiler-ast')

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation deps.kotlinpoet
     implementation deps.dagger
     implementation deps.daggerCompiler
-    implementation project(path: ':xprocessing', configuration: 'shadow')
+    implementation deps.roomCompilerProcessing
     implementation project(':lib')
     implementation project(':compiler-ast')
     implementation project(':core')

--- a/compiler/ksp/build.gradle
+++ b/compiler/ksp/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation deps.dagger
     implementation deps.daggerCompiler
     implementation deps.kspApi
-    implementation project(path: ':xprocessing', configuration: 'shadow')
+    implementation deps.roomCompilerProcessing
     implementation project(':lib')
     implementation project(':compiler')
     implementation project(':compiler-ast')

--- a/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MessageWatcher.kt
+++ b/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MessageWatcher.kt
@@ -15,12 +15,12 @@
  */
 package motif.compiler.ksp
 
+import androidx.room.compiler.processing.XAnnotation
+import androidx.room.compiler.processing.XAnnotationValue
+import androidx.room.compiler.processing.XElement
+import androidx.room.compiler.processing.XMessager
 import com.google.devtools.ksp.KspErrorThrower
 import javax.tools.Diagnostic
-import motif.compiler.processing.XAnnotation
-import motif.compiler.processing.XAnnotationValue
-import motif.compiler.processing.XElement
-import motif.compiler.processing.XMessager
 
 /**
  * A message watcher that re-throws exceptions from the KSP devtools package to work around an issue

--- a/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MotifSymbolProcessorProvider.kt
+++ b/compiler/ksp/src/main/kotlin/motif/compiler/ksp/MotifSymbolProcessorProvider.kt
@@ -15,14 +15,14 @@
  */
 package motif.compiler.ksp
 
+import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XProcessingEnvConfig
+import androidx.room.compiler.processing.ksp.KspBasicAnnotationProcessor
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import motif.compiler.MotifProcessingStep
-import motif.compiler.processing.ExperimentalProcessingApi
-import motif.compiler.processing.XProcessingEnvConfig
-import motif.compiler.processing.ksp.KspBasicAnnotationProcessor
 import motif.core.ResolvedGraph
 
 @AutoService(SymbolProcessorProvider::class)

--- a/compiler/src/main/kotlin/motif/compiler/JavaCodeGenerator.kt
+++ b/compiler/src/main/kotlin/motif/compiler/JavaCodeGenerator.kt
@@ -113,7 +113,7 @@ object JavaCodeGenerator {
           addAnnotation(Override::class.java)
           addModifiers(Modifier.PUBLIC)
           returns(childClassName.j)
-          parameters.forEach { addParameter(it.spec()) }
+          this@spec.parameters.forEach { addParameter(it.spec()) }
           addStatement("return new \$T(\$L)", childImplClassName.j, childDependenciesImpl.spec())
         }
         .build()

--- a/compiler/src/main/kotlin/motif/compiler/MotifProcessingStep.kt
+++ b/compiler/src/main/kotlin/motif/compiler/MotifProcessingStep.kt
@@ -15,11 +15,11 @@
  */
 package motif.compiler
 
-import motif.compiler.processing.ExperimentalProcessingApi
-import motif.compiler.processing.XElement
-import motif.compiler.processing.XMessager
-import motif.compiler.processing.XProcessingEnv
-import motif.compiler.processing.XProcessingStep
+import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XElement
+import androidx.room.compiler.processing.XMessager
+import androidx.room.compiler.processing.XProcessingEnv
+import androidx.room.compiler.processing.XProcessingStep
 import motif.core.ResolvedGraph
 
 @ExperimentalProcessingApi

--- a/compiler/src/main/kotlin/motif/compiler/XFunSpec.kt
+++ b/compiler/src/main/kotlin/motif/compiler/XFunSpec.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XExecutableElement
+import androidx.room.compiler.processing.XMethodElement
+import androidx.room.compiler.processing.XProcessingEnv
+import androidx.room.compiler.processing.XType
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.javapoet.KotlinPoetJavaPoetPreview
+import com.squareup.kotlinpoet.javapoet.toKTypeName
+import com.uber.xprocessing.ext.modifiers
+import javax.lang.model.element.Modifier
+import motif.compiler.KotlinTypeWorkaround.javaToKotlinType
+
+@OptIn(ExperimentalProcessingApi::class, KotlinPoetJavaPoetPreview::class)
+object XFunSpec {
+  /** Copied from [FunSpec.overriding] and modified to leverage [javaToKotlinType]& XProcessing. */
+  fun overriding(
+      executableElement: XExecutableElement,
+      enclosing: XType,
+      env: XProcessingEnv
+  ): FunSpec.Builder {
+    val methodElement =
+        (executableElement as? XMethodElement)
+            ?: throw AssertionError("Element is not a method: $executableElement")
+    val method = methodElement.asMemberOf(enclosing)
+
+    val returnType =
+        if (method.returnType.typeArguments.isNotEmpty()) {
+          method.returnType
+        } else {
+          // ensures that type arguments get loaded
+          env.requireType(method.returnType.typeName)
+        }
+
+    val builder = overriding(methodElement)
+    builder.returns(javaToKotlinType(returnType))
+
+    var i = 0
+    val size = builder.parameters.size
+    val resolvedParameterTypes = method.parameterTypes
+    while (i < size) {
+      val parameter = builder.parameters[i]
+      val type = javaToKotlinType(resolvedParameterTypes[i])
+      builder.parameters[i] = parameter.toBuilder(parameter.name, type).build()
+      i++
+    }
+
+    return builder
+  }
+
+  private fun overriding(method: XMethodElement): FunSpec.Builder {
+    var modifiers: Set<Modifier> = method.modifiers.toMutableSet()
+    require(
+        Modifier.PRIVATE !in modifiers &&
+            Modifier.FINAL !in modifiers &&
+            Modifier.STATIC !in modifiers) { "cannot override method with modifiers: $modifiers" }
+
+    val methodName = method.name
+    val funBuilder = FunSpec.builder(methodName)
+
+    funBuilder.addModifiers(KModifier.OVERRIDE)
+
+    modifiers = modifiers.toMutableSet()
+    modifiers.remove(Modifier.ABSTRACT)
+    funBuilder.jvmModifiers(modifiers)
+
+    // TODO: Unsupported until XProcessing is updated
+    /*
+            method as XParam
+                .map { it.asType() as TypeVariable }
+                .map { it.asTypeVariableName() }
+                .forEach { funBuilder.addTypeVariable(it) }
+    */
+
+    method.parameters.forEach {
+      funBuilder.addParameter(
+          ParameterSpec.builder(it.name, it.type.typeName.toKTypeName()).build())
+    }
+    if (method.isVarArgs()) {
+      funBuilder.parameters[funBuilder.parameters.lastIndex] =
+          funBuilder.parameters.last().toBuilder().addModifiers(KModifier.VARARG).build()
+    }
+
+    if (method.thrownTypes.isNotEmpty()) {
+      val throwsValueString = method.thrownTypes.joinToString { "%T::class" }
+      funBuilder.addAnnotation(
+          AnnotationSpec.builder(Throws::class)
+              .addMember(throwsValueString, *method.thrownTypes.toTypedArray())
+              .build())
+    }
+
+    return funBuilder
+  }
+}

--- a/compiler/src/main/kotlin/motif/compiler/XFunSpec.kt
+++ b/compiler/src/main/kotlin/motif/compiler/XFunSpec.kt
@@ -20,6 +20,7 @@ import androidx.room.compiler.processing.XExecutableElement
 import androidx.room.compiler.processing.XMethodElement
 import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XType
+import androidx.room.compiler.processing.compat.XConverters.toJavac
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
@@ -109,5 +110,10 @@ object XFunSpec {
     }
 
     return funBuilder
+  }
+
+  // TODO: remove after KSP support is checked in
+  private fun javaToKotlinType(mirror: XType): com.squareup.kotlinpoet.TypeName {
+    return KotlinTypeWorkaround.javaToKotlinType(mirror.toJavac())
   }
 }

--- a/compiler/src/main/kotlin/motif/compiler/XNameVisitor.kt
+++ b/compiler/src/main/kotlin/motif/compiler/XNameVisitor.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XArrayType
+import androidx.room.compiler.processing.XProcessingEnv
+import androidx.room.compiler.processing.XType
+import androidx.room.compiler.processing.compat.XConverters.getProcessingEnv
+import androidx.room.compiler.processing.compat.XConverters.toKS
+import androidx.room.compiler.processing.isArray
+import androidx.room.compiler.processing.isKotlinUnit
+import androidx.room.compiler.processing.isVoid
+import androidx.room.compiler.processing.ksp.KspTypeMapper
+import com.squareup.javapoet.TypeName
+import com.squareup.javapoet.TypeVariableName
+import com.squareup.javapoet.WildcardTypeName
+import com.uber.xprocessing.ext.isDeclaredType
+import com.uber.xprocessing.ext.isEnum
+import com.uber.xprocessing.ext.isPrimitive
+
+@OptIn(ExperimentalProcessingApi::class)
+object XNameVisitor {
+
+  fun visit(t: XType): String {
+    return when {
+      t.isVoid() -> visitNoType(t)
+      t.isError() &&
+          t.typeElement?.qualifiedName.orEmpty().let { "ERROR" in it || "NonExistent" in it } ->
+          visitError(t)
+      t.isArray() -> visitArray(t)
+      t.isWildcard() -> visitWildcard(t)
+      t.isDeclaredType() -> visitDeclared(t)
+      t.isPrimitive() -> visitPrimitive(t)
+      t.isEnum() -> visitDeclared(t)
+      t.isKotlinUnit() -> visitDeclared(t)
+      t.isTypeVariable() -> visitTypeVariable(t)
+      else -> visitNoType(t)
+    }
+  }
+
+  private fun visitPrimitive(t: XType): String {
+    return when (t.typeName) {
+      TypeName.BOOLEAN -> "Boolean"
+      TypeName.BYTE -> "Byte"
+      TypeName.SHORT -> "Short"
+      TypeName.INT -> "Integer"
+      TypeName.LONG -> "Long"
+      TypeName.CHAR -> "Character"
+      TypeName.FLOAT -> "Float"
+      TypeName.DOUBLE -> "Double"
+      else -> throw IllegalStateException()
+    }
+  }
+
+  private fun visitDeclared(t: XType, p: Void? = null): String {
+    t.typeElement?.kindName()
+    val javaQualifiedName =
+        KspTypeMapper.getPrimitiveJavaTypeName(t.typeElement?.qualifiedName.orEmpty())
+            ?.box()
+            ?.toString()
+    val simpleName =
+        javaQualifiedName?.substringAfterLast(".")
+            ?: if ("kotlin.collections.Mutable" in t.typeElement?.qualifiedName.orEmpty()) {
+              t.typeElement?.name.orEmpty().replace("Mutable", "")
+            } else {
+              t.typeElement?.name.orEmpty()
+            }
+    val enclosingElementString = t.typeElement?.enclosingTypeElement?.name.orEmpty()
+
+    val rawString = "$enclosingElementString$simpleName"
+
+    if (t.typeArguments.isEmpty() || t.toString().startsWith("raw ")) {
+      return rawString
+    }
+
+    if (t.getProcessingEnv().backend == XProcessingEnv.Backend.KSP &&
+        t.typeArguments.any { it.isError() }) {
+      val raw = t.typeElement?.name.orEmpty()
+      val args = t.toKS().arguments.map { "$it".substringAfter(" ") }.joinToString("")
+      return "$args$raw"
+    }
+
+    val typeArgumentString = t.typeArguments.map { visit(it) }.joinToString("")
+
+    return "$typeArgumentString$rawString"
+  }
+
+  private fun visitArray(t: XArrayType, p: Void? = null): String {
+    return visit(t.componentType) + "Array"
+  }
+
+  private fun visitTypeVariable(t: XType, p: Void? = null): String {
+    return t.typeName.toString().capitalize()
+  }
+
+  private fun visitWildcard(t: XType, p: Void? = null): String {
+    if (t.typeName.toString() == "?" || t.typeName.toString() == "*") {
+      return ""
+    }
+    return t.extendsBound()?.let {
+      return visit(it)
+    }
+        ?: ""
+  }
+
+  private fun visitNoType(t: XType): String {
+    return if (t.isVoid()) "Void" else defaultAction(t)
+  }
+
+  private fun visitError(t: XType, p: Void? = null): String {
+    throw IllegalStateException(
+        "Could not generate name for ErrorType: $t. Check your code for missing imports or typos.")
+  }
+
+  private fun defaultAction(t: XType?): String {
+    throw IllegalArgumentException("Unexpected type mirror: $t")
+  }
+}
+
+private fun XType.isWildcard(): Boolean {
+  return typeName is WildcardTypeName
+}
+
+private fun XType.isTypeVariable(): Boolean {
+  return typeName is TypeVariableName
+}


### PR DESCRIPTION
Adds two utilities for Kotlin codegen using XProcessing APIs that will be needed in #211 . The first is a port of `MethodSpec.overrides` from JavaPoet and the second is a port of `javax.lang.model.util.SimpleTypeVisitor` for generating var and fun names.