### PR TITLE
Migrate test classes to XProcessing APIs

### DIFF
--- a/compiler/ast/src/test/kotlin/motif/ast/compiler/CompilerClassTest.kt
+++ b/compiler/ast/src/test/kotlin/motif/ast/compiler/CompilerClassTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Uber Technologies, Inc.
+ * Copyright (c) 2022 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,154 +16,260 @@
 package motif.ast.compiler
 
 import androidx.room.compiler.processing.ExperimentalProcessingApi
-import androidx.room.compiler.processing.XProcessingEnv
-import com.google.common.truth.Truth.assertAbout
+import androidx.room.compiler.processing.util.Source
+import androidx.room.compiler.processing.util.XTestInvocation
+import androidx.room.compiler.processing.util.runKspTest
+import androidx.room.compiler.processing.util.runProcessorTestWithoutKsp
+import autovalue.shaded.com.`google$`.common.collect.`$Sets`.cartesianProduct
 import com.google.common.truth.Truth.assertThat
-import com.google.testing.compile.JavaFileObjects
-import com.google.testing.compile.JavaSourceSubjectFactory.javaSource
-import javax.annotation.processing.AbstractProcessor
-import javax.annotation.processing.RoundEnvironment
-import javax.lang.model.element.TypeElement
 import org.intellij.lang.annotations.Language
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
+@RunWith(Parameterized::class)
 @OptIn(ExperimentalProcessingApi::class)
-class CompilerClassTest {
+class XCompilerClassTest(
+    private val processorType: ProcessorType,
+    private val srcLang: SourceLanguage
+) {
+
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "{0}_{1}")
+    fun data(): Collection<Array<Any>> {
+      return cartesianProduct(ProcessorType.values().toSortedSet(), SourceLanguage.values().toSortedSet())
+          .filterNot { (proc, _) -> proc == ProcessorType.KSP } // Investigate this after ksp#1086
+          .filterNot { (proc, srcLang) ->
+            proc == ProcessorType.AP && srcLang == SourceLanguage.KOTLIN
+          }
+          .map { it.toTypedArray() as Array<Any> }
+          .toList()
+    }
+  }
 
   @Test
   fun testSupertypeTypeArguments() {
-    val fooClass =
-        createClass(
-            "test.Foo",
-            """
-            package test;
+    createClass(
+        "test.Foo",
+        """
+          package test;
 
-            class Bar<T> {}
+          abstract class Bar<T> {}
 
-            class Foo extends Bar<String> {}
-        """.trimIndent())
-
-    val superClass = fooClass.supertypes.single().resolveClass() as CompilerClass
-    assertThat(superClass.typeArguments.map { it.qualifiedName })
-        .containsExactly("java.lang.String")
+          class Foo extends Bar<String> {}
+      """.trimIndent()) {
+        fooClass ->
+      val superClass = fooClass.supertypes.single().resolveClass() as CompilerClass
+      assertThat(superClass.typeArguments.map { it.qualifiedName })
+          .containsExactly("java.lang.String")
+    }
   }
 
   @Test
   fun testSupertypeTypeArguments_intermediateClass() {
-    val fooClass =
-        createClass(
-            "test.Foo",
-            """
-            package test;
+    createClass(
+        "test.Foo",
+        """
+          package test;
 
-            class Baz<T> {}
+          class Baz<T> {}
 
-            class Bar<T> extends Baz<T> {}
+          class Bar<T> extends Baz<T> {}
 
-            class Foo extends Bar<String> {}
-        """.trimIndent())
-
-    val barClass = fooClass.supertypes.single().resolveClass() as CompilerClass
-    val bazClass = barClass.supertypes.single().resolveClass() as CompilerClass
-    assertThat(bazClass.typeArguments.map { it.qualifiedName }).containsExactly("java.lang.String")
+          class Foo extends Bar<String> {}
+      """.trimIndent()) {
+        fooClass ->
+      val barClass = fooClass.supertypes.single().resolveClass() as CompilerClass
+      val bazClass = barClass.supertypes.single().resolveClass() as CompilerClass
+      assertThat(bazClass.typeArguments.map { it.qualifiedName })
+          .containsExactly("java.lang.String")
+    }
   }
 
   @Test
   fun testSupertypeTypeArguments_typeVariable() {
-    val fooClass =
-        createClass(
-            "test.Foo",
-            """
-            package test;
+    createClass(
+        "test.Foo",
+        """
+          package test;
 
-            class Bar<T> {}
+          class Bar<T> {}
 
-            class Foo<T> extends Bar<T> {}
-        """.trimIndent())
-
-    val superClass = fooClass.supertypes.single().resolveClass() as CompilerClass
-    assertThat(superClass.typeArguments).isEmpty()
+          class Foo<T> extends Bar<T> {}
+      """.trimIndent()) {
+        fooClass ->
+      val superClass = fooClass.supertypes.single().resolveClass() as CompilerClass
+      assertThat(superClass.typeArguments).isEmpty()
+    }
   }
 
   @Test
   fun testObjectSupertype() {
-    val fooClass =
-        createClass(
-            "test.Foo",
-            """
-            package test;
+    createClass(
+        "test.Foo", """
+          package test;
 
-            class Foo {}
-        """.trimIndent())
-
-    val objectClass = fooClass.supertypes.single().resolveClass()!!
-    assertThat(objectClass.qualifiedName).isEqualTo("java.lang.Object")
-    assertThat(objectClass.supertypes).isEmpty()
+          class Foo {}
+      """.trimIndent()) {
+        fooClass ->
+      val objectClass = fooClass.supertypes.single().resolveClass()!!
+      assertThat(objectClass.qualifiedName).isEqualTo(listOf("java.lang.Object").forLang().first())
+      assertThat(objectClass.supertypes).isEmpty()
+    }
   }
 
   @Test
   fun testSupertypeOnlyInterface() {
-    val fooClass =
-        createClass(
-            "test.Foo",
-            """
-            package test;
+    createClass(
+        "test.Foo",
+        """
+          package test;
 
-            interface Bar {}
+          interface Bar {}
 
-            class Foo implements Bar {}
-        """.trimIndent())
-
-    val superTypes = fooClass.supertypes.map { it.qualifiedName }
-    assertThat(superTypes).containsExactly("java.lang.Object", "test.Bar")
+          class Foo implements Bar {}
+      """.trimIndent()) {
+        fooClass ->
+      val superTypes = fooClass.supertypes.map { it.qualifiedName }
+      assertThat(superTypes)
+          .containsExactly(
+              *listOf("java.lang.Object", "test.Bar")
+                  .forLang()
+                  .filter { it != "kotlin.Any" }
+                  .toTypedArray())
+    }
   }
 
   @Test
   fun testSupertypeMultipleInterfaces() {
-    val fooClass =
-        createClass(
-            "test.Foo",
-            """
-            package test;
+    createClass(
+        "test.Foo",
+        """
+          package test;
 
-            interface Bar {}
+          interface Bar {}
 
-            interface Baz {}
+          interface Baz {}
 
-            class Foo implements Bar, Baz {}
-        """.trimIndent())
-
-    val superTypes = fooClass.supertypes.map { it.qualifiedName }
-    assertThat(superTypes).containsExactly("java.lang.Object", "test.Bar", "test.Baz")
+          class Foo implements Bar, Baz {}
+      """.trimIndent()) {
+        fooClass ->
+      val superTypes = fooClass.supertypes.map { it.qualifiedName }
+      assertThat(superTypes)
+          .containsExactly(
+              *listOf("java.lang.Object", "test.Bar", "test.Baz")
+                  .forLang()
+                  .filter { it != "kotlin.Any" }
+                  .toTypedArray())
+    }
   }
 
-  private fun createClass(qualifiedName: String, @Language("JAVA") text: String): CompilerClass {
-    var compilerClass: CompilerClass? = null
-    assertAbout(javaSource())
-        .that(JavaFileObjects.forSourceString(qualifiedName, text))
-        .processedWith(
-            object : AbstractProcessor() {
-
-              override fun getSupportedAnnotationTypes(): Set<String> {
-                return setOf("*")
-              }
-
-              override fun process(
-                  annotations: Set<TypeElement>,
-                  roundEnv: RoundEnvironment
-              ): Boolean {
-                val env = XProcessingEnv.create(processingEnv)
-                val typeElement =
-                    env.findTypeElement(qualifiedName)
-                        ?: throw IllegalStateException("No type element found for: $qualifiedName")
-                val declaredType = env.getDeclaredType(typeElement)
-                compilerClass = CompilerClass(env, declaredType)
-                return false
-              }
-            })
-        .compilesWithoutError()
-
-    assertThat(compilerClass).isNotNull()
-    return compilerClass!!
+  private fun createClass(
+      qualifiedName: String,
+      @Language("JAVA") text: String,
+      assertions: (CompilerClass) -> Unit
+  ) {
+    val pkg = text.lines().firstOrNull { it.startsWith("package ")  }?.substringAfter(" ")?.substringBefore(";") ?: "test"
+    val srcFiles = text.split("\n{2,}".toRegex()).filterNot { it.startsWith("package") }
+    val sources = when (srcLang) {
+      SourceLanguage.JAVA -> createJavaSources(srcFiles, pkg)
+      SourceLanguage.KOTLIN -> createKotlinSources(srcFiles, pkg)
+    }
+    return when (processorType) {
+      ProcessorType.AP -> runProcessorTestWithoutKsp(sources) { invocation ->
+        process(invocation, qualifiedName, assertions)
+      }
+      ProcessorType.KSP -> runKspTest(sources) { invocation ->
+        process(invocation, qualifiedName, assertions)
+      }
+    }
   }
+
+  private fun process(
+    invocation: XTestInvocation,
+    qualifiedName: String,
+    assertions: (CompilerClass) -> Unit
+  ): CompilerClass {
+    val env = invocation.processingEnv
+    val typeElement = env.findTypeElement(qualifiedName)
+        ?: throw IllegalStateException("No type element found for: $qualifiedName")
+    val declaredType = env.getDeclaredType(typeElement)
+    val compilerClass = CompilerClass(env, declaredType)
+    assertions.invoke(compilerClass)
+    invocation.assertCompilationResult { this.hasErrorCount(0) }
+    return compilerClass
+  }
+
+  // Map the 1 multiline Java string to multiple source files so that types are properly resolved
+  private fun createJavaSources(srcFiles: List<String>, pkg: String): List<Source> {
+    return srcFiles.map { src ->
+      val name =
+        "(class|interface)\\s+\\w+".toRegex().find(src)?.value?.substringAfterLast(" ") ?: "Unknown"
+      val imports = setOf("Foo", "Bar", "Baz").filter { it != name && it in src }.map { "import $pkg.$it;" }.joinToString("\n")
+      val code = """
+        package $pkg;
+        $imports
+
+        $src
+      """.trimIndent()
+      return@map Source.java("$pkg.$name", code)
+    }
+  }
+
+  // Map the 1 multiline Java string to multiple KT source files so that types are properly resolved
+  private fun createKotlinSources(srcFiles: List<String>, pkg: String): List<Source> {
+    return srcFiles
+      .map { it.replace("implements", ":").replace("extends", ":").replace(";", "") }
+      .map { src ->
+        val name =
+            "(class|interface)\\s+\\w+".toRegex().find(src)?.value?.substringAfterLast(" ") ?: "Unknown"
+        val imports = setOf("Foo", "Bar", "Baz").filter { it != name && it in src }.map { "import $pkg.$it" }.joinToString("\n")
+        val hasParentClass = ":" in src && src.substringAfter(" : ").substringBeforeLast(" ").substringBefore("<").let {
+          srcFiles.any { src -> "class $it" in src }
+        }
+
+        val code = """
+          package $pkg
+          import kotlin.String
+          $imports
+
+          ${if (hasParentClass) src.replace(" {}", "() {}") else src}
+        """.trimIndent()
+        return@map Source.kotlin("$pkg/$name.kt", code)
+      }
+  }
+
+  private fun String.toSourceFor(): String {
+    return if (srcLang == SourceLanguage.KOTLIN) {
+      this
+    } else {
+      this.replace("open ", "")
+    }
+  }
+
+  private fun List<String>.forLang(): Array<String> {
+    return if (srcLang == SourceLanguage.KOTLIN) {
+          map {
+            when (it) {
+              "java.lang.Object" -> "kotlin.Any"
+              "java.lang.String" -> "kotlin.String"
+              else -> it
+            }
+          }
+        } else {
+          this
+        }
+        .toTypedArray()
+  }
+}
+
+enum class ProcessorType {
+  AP,
+  KSP
+}
+
+enum class SourceLanguage {
+  JAVA,
+  KOTLIN
 }

--- a/compiler/src/main/kotlin/motif/compiler/CodeGenerator.kt
+++ b/compiler/src/main/kotlin/motif/compiler/CodeGenerator.kt
@@ -70,3 +70,8 @@ object CodeGenerator {
         .map { "${it.packageName}.${it.name}" }
   }
 }
+
+enum class Mode {
+  JAVA, // Generate pure Java implementation
+  KOTLIN, // Generate pure Kotlin implementation
+}

--- a/compiler/src/main/kotlin/motif/compiler/Processor.kt
+++ b/compiler/src/main/kotlin/motif/compiler/Processor.kt
@@ -23,11 +23,6 @@ import motif.core.ResolvedGraph
 const val OPTION_KAPT_KOTLIN_GENERATED = "kapt.kotlin.generated"
 const val OPTION_MODE = "motif.mode"
 
-enum class Mode {
-  JAVA, // Generate pure Java implementation
-  KOTLIN, // Generate pure Kotlin implementation
-}
-
 class Processor : JavacBasicAnnotationProcessor() {
   lateinit var graph: ResolvedGraph
 

--- a/compiler/src/main/kotlin/motif/compiler/XNameVisitor.kt
+++ b/compiler/src/main/kotlin/motif/compiler/XNameVisitor.kt
@@ -77,7 +77,13 @@ object XNameVisitor {
             } else {
               t.typeElement?.name.orEmpty()
             }
-    val enclosingElementString = t.typeElement?.enclosingTypeElement?.name.orEmpty()
+    val enclosingElementString = t.typeElement?.enclosingTypeElement?.name.orEmpty().let {
+      return@let if ("kotlin.collections.Mutable" in t.typeElement?.enclosingTypeElement?.qualifiedName.orEmpty()) {
+        it.replace("Mutable", "")
+      } else {
+        it
+      }
+    }
 
     val rawString = "$enclosingElementString$simpleName"
 

--- a/compiler/src/main/kotlin/motif/compiler/XNameVisitor.kt
+++ b/compiler/src/main/kotlin/motif/compiler/XNameVisitor.kt
@@ -77,13 +77,15 @@ object XNameVisitor {
             } else {
               t.typeElement?.name.orEmpty()
             }
-    val enclosingElementString = t.typeElement?.enclosingTypeElement?.name.orEmpty().let {
-      return@let if ("kotlin.collections.Mutable" in t.typeElement?.enclosingTypeElement?.qualifiedName.orEmpty()) {
-        it.replace("Mutable", "")
-      } else {
-        it
-      }
-    }
+    val enclosingElementString =
+        t.typeElement?.enclosingTypeElement?.name.orEmpty().let {
+          return@let if ("kotlin.collections.Mutable" in
+              t.typeElement?.enclosingTypeElement?.qualifiedName.orEmpty()) {
+            it.replace("Mutable", "")
+          } else {
+            it
+          }
+        }
 
     val rawString = "$enclosingElementString$simpleName"
 

--- a/compiler/src/test/java/motif/compiler/NamesTest.kt
+++ b/compiler/src/test/java/motif/compiler/NamesTest.kt
@@ -116,8 +116,7 @@ class XNamesTest(private val processorType: ProcessorType, private val srcLang: 
 
   @Test
   fun named() {
-    assertSafeName(
-        "String", "String", "fooString", "@javax.inject.Named(\"Foo\")")
+    assertSafeName("String", "String", "fooString", "@javax.inject.Named(\"Foo\")")
   }
 
   @Test
@@ -145,10 +144,15 @@ class XNamesTest(private val processorType: ProcessorType, private val srcLang: 
     assertErrorMessage("java.util.HashMap<DoesNotExist, Integer>", "DoesNotExist")
   }
 
-  private fun compile(classString: String, qualifierString: String, assertion: (XTestInvocation, String) -> Unit) {
+  private fun compile(
+      classString: String,
+      qualifierString: String,
+      assertion: (XTestInvocation, String) -> Unit
+  ) {
     when (processorType) {
       ProcessorType.AP -> {
-        runProcessorTestWithoutKsp(sources = getSources(classString, qualifierString)) { invocation ->
+        runProcessorTestWithoutKsp(sources = getSources(classString, qualifierString)) { invocation
+          ->
           val safeName = process(invocation)
           assertion(invocation, safeName)
         }

--- a/compiler/src/test/java/motif/compiler/TestParameters.kt
+++ b/compiler/src/test/java/motif/compiler/TestParameters.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.compiler
+
+import java.io.File
+
+data class TestParameters(
+    @get:JvmName("testDirectory") val testDirectory: File,
+    @get:JvmName("processorType") val processorType: ProcessorType,
+    @get:JvmName("sourceLanguage") val sourceLanguage: SourceLanguage,
+)
+
+enum class ProcessorType {
+    AP,
+    KSP
+}
+
+enum class SourceLanguage {
+    JAVA,
+    KOTLIN
+}

--- a/compiler/src/test/java/motif/compiler/TestParameters.kt
+++ b/compiler/src/test/java/motif/compiler/TestParameters.kt
@@ -24,11 +24,11 @@ data class TestParameters(
 )
 
 enum class ProcessorType {
-    AP,
-    KSP
+  AP,
+  KSP
 }
 
 enum class SourceLanguage {
-    JAVA,
-    KOTLIN
+  JAVA,
+  KOTLIN
 }


### PR DESCRIPTION
Migrate all test classes and utils except for TestHarness to use XProcessing APIs for #211 