### PR TITLE
Update LineMarkerInfo calls to avoid method marked for removal

### DIFF
--- a/intellij/src/main/kotlin/motif/intellij/provider/ScopeHierarchyLineMarkerProvider.kt
+++ b/intellij/src/main/kotlin/motif/intellij/provider/ScopeHierarchyLineMarkerProvider.kt
@@ -70,10 +70,9 @@ class ScopeHierarchyLineMarkerProvider : LineMarkerProvider, MotifService.Listen
         element,
         identifier.textRange,
         AllIcons.Hierarchy.Supertypes,
-        UPDATE_ALL,
         ConstantFunction<PsiElement, String>(LABEL_ANCESTORS_SCOPE),
         ScopeHierarchyHandler(element.project),
-        LEFT)
+        LEFT) { LABEL_ANCESTORS_SCOPE }
   }
 
   private class ScopeHierarchyHandler(val project: Project) :

--- a/intellij/src/main/kotlin/motif/intellij/provider/ScopeNavigationLineMarkerProvider.kt
+++ b/intellij/src/main/kotlin/motif/intellij/provider/ScopeNavigationLineMarkerProvider.kt
@@ -48,6 +48,7 @@ import motif.intellij.analytics.AnalyticsService
 import motif.intellij.analytics.MotifAnalyticsActions
 import motif.intellij.toPsiClass
 import motif.intellij.toPsiMethod
+import java.util.function.Supplier
 
 /*
  * {@LineMarkerProvider} used to display navigation icons in gutter to navigate to parent/children of Motif scopes.
@@ -81,10 +82,9 @@ class ScopeNavigationLineMarkerProvider : LineMarkerProvider, MotifService.Liste
             element,
             identifier.textRange,
             AllIcons.Actions.PreviousOccurence,
-            UPDATE_ALL,
             ConstantFunction<PsiElement, String>(LABEL_NAVIGATE_PARENT_SCOPE),
             NavigationScopeHandler(element.project, graph),
-            LEFT)
+            LEFT) { LABEL_NAVIGATE_PARENT_SCOPE }
       }
     } else {
       val methodElement = element.toPsiMethod()
@@ -93,10 +93,10 @@ class ScopeNavigationLineMarkerProvider : LineMarkerProvider, MotifService.Liste
             element,
             element.textRange,
             AllIcons.Actions.NextOccurence,
-            UPDATE_ALL,
             ConstantFunction<PsiElement, String>(LABEL_NAVIGATE_CHILD_SCOPE),
             NavigationScopeHandler(element.project, graph),
-            LEFT)
+            LEFT
+        ) { LABEL_NAVIGATE_CHILD_SCOPE }
       }
     }
     return null


### PR DESCRIPTION
**Description**: Currently we use a deprecated `LineMarkerInfo` call in 3 places. The call we are using is [marked for removal](https://github.com/jetbrains/intellij-community/blob/master/platform/lang-api/src/com/intellij/codeInsight/daemon/LineMarkerInfo.java#L150), and causes non-fatal errors in the latest version of IntelliJ (2023.2.x). This PR updates the call to the currently recommended method.