### PR TITLE
Update Dokka to Support Kotlin 1.9

### DIFF
--- a/ast/build.gradle
+++ b/ast/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
     id 'com.vanniktech.maven.publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.dokka.gradle.DokkaTaskPartial
+
 // https://github.com/gradle/gradle/issues/4848
 gradle.startParameter.configureOnDemand = false
 
@@ -101,5 +103,12 @@ subprojects {
                 endWithNewline()
             }
         }
+    }
+
+    apply plugin: 'org.jetbrains.dokka'
+    tasks.withType(DokkaTaskPartial).configureEach {
+        outputDirectory.set(new File(buildDir, "docs/partial"))
+        moduleName.set(project.property("POM_ARTIFACT_ID").toString())
+        moduleVersion.set(project.property("VERSION_NAME").toString())
     }
 }

--- a/compiler/ast/build.gradle
+++ b/compiler/ast/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
     id 'com.vanniktech.maven.publish'
 }
 

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
     id 'com.vanniktech.maven.publish'
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
     id 'com.vanniktech.maven.publish'
 }
 

--- a/errormessage/build.gradle
+++ b/errormessage/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
     id 'com.vanniktech.maven.publish'
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -26,7 +26,7 @@ def versions = [
         kotlinpoet: '1.12.0',
         room: '2.1.0',
         roomCompilerProcessing: '2.6.0-alpha02',
-        dokka: '1.4.32',
+        dokka: '1.9.10',
         "gradleIntellijPlugin": [
                 ide: '2023.2'
         ],
@@ -46,7 +46,7 @@ ext.deps = [
                         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
                         ksp: "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:${versions.ksp}",
                         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
-                        mavenPublish: 'com.vanniktech:gradle-maven-publish-plugin:0.18.0',
+                        mavenPublish: 'com.vanniktech:gradle-maven-publish-plugin:0.27.0',
                         spotless: "com.diffplug.spotless:spotless-plugin-gradle:5.11.0",
                         shadow: "com.github.johnrengelman:shadow:8.1.0",
                 ]

--- a/intellij/ast/build.gradle
+++ b/intellij/ast/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "org.jetbrains.intellij" version "1.15.0"
     id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
     id 'com.vanniktech.maven.publish'
 }
 

--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "org.jetbrains.intellij" version "1.15.0"
     id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
     id 'com.vanniktech.maven.publish'
 }
 

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
     id 'com.vanniktech.maven.publish'
 }
 

--- a/viewmodel/build.gradle
+++ b/viewmodel/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
     id 'com.vanniktech.maven.publish'
 }
 


### PR DESCRIPTION
Similar to the series of simple-store pull requests https://github.com/uber/simple-store/pull/96, https://github.com/uber/simple-store/pull/97, and https://github.com/uber/simple-store/pull/98.

This pull request updates our document publishing flows such that when we update kotlin to 1.9+ in motif, we can still build/publish changes.