### PR TITLE
Unify tests/samples naming pattern

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,9 +106,11 @@ subprojects {
     }
 
     apply plugin: 'org.jetbrains.dokka'
-    tasks.withType(DokkaTaskPartial).configureEach {
-        outputDirectory.set(new File(buildDir, "docs/partial"))
-        moduleName.set(project.property("POM_ARTIFACT_ID").toString())
-        moduleVersion.set(project.property("VERSION_NAME").toString())
+    if (!project.name.contains("samples") && !project.name.contains("tests")) {
+        tasks.withType(DokkaTaskPartial).configureEach {
+            outputDirectory.set(new File(buildDir, "docs/partial"))
+            moduleName.set(project.property("POM_ARTIFACT_ID").toString())
+            moduleVersion.set(project.property("VERSION_NAME").toString())
+        }
     }
 }

--- a/samples/sample/build.gradle
+++ b/samples/sample/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     annotationProcessor deps.butterknifeCompiler
     annotationProcessor deps.glideCompiler
     annotationProcessor project(':compiler')
-    implementation project(':samples:sample-lib')
+    implementation project(':samples-sample-lib')
     implementation project(':lib')
     implementation deps.glide
     implementation deps.stetho
@@ -47,5 +47,4 @@ dependencies {
 
     testImplementation deps.test.junit
     testImplementation deps.test.truth
-
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,23 +29,24 @@ pluginManagement {
 }
 
 rootProject.name = 'motif'
-include 'lib'
+include 'ast'
 include 'compiler'
 include 'compiler-ast'
 include 'compiler-ksp'
-include 'samples:sample'
-include 'samples:sample-lib'
-include 'samples:sample-kotlin'
-include 'samples:sample-kotlin-ksp'
-include 'samples:dagger-comparison'
-include 'intellij'
-include 'intellij-ast'
 include 'core'
 include 'errormessage'
+include 'intellij'
+include 'intellij-ast'
+include 'lib'
 include 'models'
-include 'ast'
+include 'samples-dagger-comparison'
+include 'samples-sample'
+include 'samples-sample-kotlin'
+include 'samples-sample-kotlin-ksp'
+include 'samples-sample-lib'
+include 'samples-sample-lib-ksp'
 include 'tests'
-include 'tests:compiler'
+include 'tests-compiler'
 include 'viewmodel'
 include 'xprocessing'
 include 'xprocessing-testing'
@@ -53,4 +54,10 @@ include 'xprocessing-testing'
 project(':compiler-ast').projectDir = file('compiler/ast')
 project(':compiler-ksp').projectDir = file('compiler/ksp')
 project(':intellij-ast').projectDir = file('intellij/ast')
-include ':samples:sample-lib-ksp'
+project(':samples-dagger-comparison').projectDir = file('samples/dagger-comparison')
+project(':samples-sample').projectDir = file('samples/sample')
+project(':samples-sample-kotlin').projectDir = file('samples/sample-kotlin')
+project(':samples-sample-kotlin-ksp').projectDir = file('samples/sample-kotlin-ksp')
+project(':samples-sample-lib').projectDir = file('samples/sample-lib')
+project(':samples-sample-lib-ksp').projectDir = file('samples/sample-lib-ksp')
+project(':tests-compiler').projectDir = file('tests/compiler')

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -17,7 +17,7 @@ kotlin {
 }
 
 dependencies {
-    kapt project(':tests:compiler')
+    kapt project(':tests-compiler')
     kapt deps.daggerCompiler
     implementation project(':core')
     implementation project(':lib')


### PR DESCRIPTION
This pull request addresses an omission in https://github.com/uber/motif/pull/262, where we'd attempt to generate documents even for sample and test modules, which are not published.

In doing so, we noticed an opportunity to make the naming pattern more consistent for all nested modules in the project - namely, the `:compiler:ast` is `compiler-ast` (we figured it's for ease of publication), but despite the `samples` and `tests` modules being unpublished, unifying the naming pattern could make it look/feel more consistent and make preventing document generation a bit easier.