### PR TITLE
Fix hashCode/equals contract violation in XType.hash()

### DIFF
--- a/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XType.kt
+++ b/compiler/ast/src/main/kotlin/com/uber/xprocessing/ext/XType.kt
@@ -172,10 +172,8 @@ fun XType.hash(): Int =
     } catch (t: Throwable) {
       if (typeArguments.any { it.typeName is WildcardTypeName && it.typeName.toString() != "?" }) {
         extendsBoundOrSelf().typeName.toString().hashCode()
-      } else if (this.hasCollectionType()) {
-        typeName.removeWildcardTypeIfContains().toString().hashCode()
       } else {
-        hashCode()
+        typeName.removeWildcardTypeIfContains().toString().hashCode()
       }
     }
 
@@ -298,10 +296,6 @@ fun XType.isDeclaredType(): Boolean =
 fun XType.isEnum(): Boolean = typeElement?.isEnum() ?: false
 
 fun XType.isPrimitive(): Boolean = typeName.isPrimitive
-
-private fun XType.hasCollectionType(): Boolean =
-    this.typeElement?.name.orEmpty() in collectionTypes ||
-        typeArguments.any { it.hasCollectionType() }
 
 private val collectionTypes =
     setOf("MutableList", "MutableSet", "MutableCollection", "List", "Set", "Collection")

--- a/compiler/ast/src/test/kotlin/motif/ast/compiler/CompilerTypeHashTest.kt
+++ b/compiler/ast/src/test/kotlin/motif/ast/compiler/CompilerTypeHashTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package motif.ast.compiler
+
+import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.util.Source
+import androidx.room.compiler.processing.util.runKspTest
+import com.google.common.truth.Truth.assertThat
+import com.uber.xprocessing.ext.hash
+import com.uber.xprocessing.ext.isEquivalent
+import org.junit.Test
+
+@OptIn(ExperimentalProcessingApi::class)
+class CompilerTypeHashTest {
+
+  @Test
+  fun hashEqualsContractForParameterizedType() {
+    val sources =
+        listOf(
+            Source.kotlin(
+                "test/Wrapper.kt",
+                """
+                package test
+                class Wrapper<T>(val value: T)
+                """
+                    .trimIndent(),
+            ),
+            Source.java(
+                "test.JavaUser",
+                """
+                package test;
+                public class JavaUser {
+                    public Wrapper<String> provide() { return null; }
+                }
+                """
+                    .trimIndent(),
+            ),
+            Source.kotlin(
+                "test/KotlinUser.kt",
+                """
+                package test
+                class KotlinUser {
+                    fun provide(): Wrapper<String> = Wrapper("s")
+                }
+                """
+                    .trimIndent(),
+            ),
+        )
+
+    runKspTest(sources) { invocation ->
+      val env = invocation.processingEnv
+
+      val javaClass = env.findTypeElement("test.JavaUser")!!
+      val kotlinClass = env.findTypeElement("test.KotlinUser")!!
+
+      val javaReturnType = javaClass.getDeclaredMethods().first { it.name == "provide" }.returnType
+      val kotlinReturnType =
+          kotlinClass.getDeclaredMethods().first { it.name == "provide" }.returnType
+
+      assertThat(javaReturnType.isEquivalent(kotlinReturnType, env)).isTrue()
+      assertThat(javaReturnType.hash()).isEqualTo(kotlinReturnType.hash())
+
+      val type1 = CompilerType(env, javaReturnType)
+      val type2 = CompilerType(env, kotlinReturnType)
+      assertThat(type1).isEqualTo(type2)
+      assertThat(type1.hashCode()).isEqualTo(type2.hashCode())
+
+      val map = HashMap<CompilerType, String>()
+      map[type1] = "first"
+      map.putIfAbsent(type2, "should-not-appear")
+      assertThat(map).hasSize(1)
+      assertThat(map[type1]).isEqualTo("first")
+      assertThat(map[type2]).isEqualTo("first")
+
+      invocation.assertCompilationResult { hasErrorCount(0) }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Motif. Before pressing the "Create Pull Request" button, please consider the following
points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Fix hashCode/equals contract violation in XType.hash() that caused duplicate type entries in the scope graph when mixing Java and Kotlin sources after migrating to KSP2. In KSP2, equivalent parameterized types from Java and Kotlin sources produce distinct XType instances (KSP1 cached/shared them), exposing a latent bug: the else branch used identity-based hashCode() while equals() delegates to value-based  isEquivalent(). Replace with typeName.removeWildcardTypeIfContains().toString().hashCode() to match the equivalence logic, and remove the now-redundant hasCollectionType branch.

**Testing**:
Add unit test that reproduces the bug using mixed Java+Kotlin sources returning the same parameterized type  (Wrapper<String>)


<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
